### PR TITLE
Fix insight card formatting for structured mentions

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -24,7 +24,7 @@ import {
 } from './config/constants';
 
 // Utils
-import { safeString, removeUndefined } from './utils/string';
+import { safeString, removeUndefined, formatMentions } from './utils/string';
 import { safeDate } from './utils/date';
 import { sanitizeEntry } from './utils/entries';
 
@@ -1171,7 +1171,7 @@ const EntryCard = ({ entry, onDelete, onUpdate }) => {
 
   useEffect(() => { setTitle(entry.title); }, [entry.title]);
 
-  const insightMsg = entry.contextualInsight?.message ? safeString(entry.contextualInsight.message) : null;
+  const insightMsg = entry.contextualInsight?.message ? formatMentions(safeString(entry.contextualInsight.message)) : null;
   const cbt = entry.analysis?.cbt_breakdown;
   const ventSupport = entry.analysis?.vent_support;
   const celebration = entry.analysis?.celebration;

--- a/src/utils/string.js
+++ b/src/utils/string.js
@@ -9,6 +9,36 @@ export const safeString = (val) => {
 };
 
 /**
+ * Format structured mentions (@person:name, @place:location, etc.) for display
+ * Converts @person:spencer_jones to "Spencer Jones"
+ */
+export const formatMentions = (text) => {
+  if (typeof text !== 'string') return text;
+
+  return text
+    // Handle @person:name -> Name (capitalize and replace underscores)
+    .replace(/@person:([a-z0-9_]+)/gi, (_, name) =>
+      name.split('_').map(w => w.charAt(0).toUpperCase() + w.slice(1)).join(' ')
+    )
+    // Handle @place:location -> Location
+    .replace(/@place:([a-z0-9_]+)/gi, (_, place) =>
+      place.split('_').map(w => w.charAt(0).toUpperCase() + w.slice(1)).join(' ')
+    )
+    // Handle @goal:description -> "description" (keep lowercase, more readable)
+    .replace(/@goal:([a-z0-9_]+)/gi, (_, goal) =>
+      goal.replace(/_/g, ' ')
+    )
+    // Handle @situation:context -> "context"
+    .replace(/@situation:([a-z0-9_]+)/gi, (_, situation) =>
+      situation.replace(/_/g, ' ')
+    )
+    // Handle @self:statement -> "statement"
+    .replace(/@self:([a-z0-9_]+)/gi, (_, statement) =>
+      statement.replace(/_/g, ' ')
+    );
+};
+
+/**
  * Recursively remove undefined values from objects and arrays
  */
 export const removeUndefined = (obj) => {


### PR DESCRIPTION
Add formatMentions utility that transforms raw @person:name, @place:location, @goal:, @situation:, and @self: tags into human-readable text. Applied to insight messages so "@person:Spencer" displays as "Spencer" instead of the raw tag format.