### PR TITLE
Fix entry save error and update Gemini model

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -436,10 +436,7 @@ export default function App() {
       const ref = await addDoc(collection(db, 'artifacts', APP_COLLECTION_ID, 'users', user.uid, 'entries'), entryData);
 
       setProcessing(false);
-      setMode('idle');
       setReplyContext(null);
-      setShowPrompts(false);
-      setPromptMode(null);
 
       (async () => {
         try {

--- a/src/config/ai.js
+++ b/src/config/ai.js
@@ -5,7 +5,7 @@ export const OPENAI_API_KEY = import.meta.env.VITE_OPENAI_API_KEY;
 // AI Model Configuration
 export const AI_CONFIG = {
   classification: {
-    primary: 'gemini-1.5-flash',
+    primary: 'gemini-2.0-flash',
     fallback: 'gpt-4o-mini'
   },
   analysis: {
@@ -14,7 +14,7 @@ export const AI_CONFIG = {
   },
   chat: {
     primary: 'gpt-4o-mini',
-    fallback: 'gemini-1.5-flash'
+    fallback: 'gemini-2.0-flash'
   },
   embedding: {
     primary: 'text-embedding-004',

--- a/src/services/prompts/index.js
+++ b/src/services/prompts/index.js
@@ -140,7 +140,7 @@ Rules:
 - Examples: "How did that meeting go?", "Any updates on the apartment search?"`;
 
   try {
-    const raw = await callGemini(prompt, '', 'gemini-1.5-flash');
+    const raw = await callGemini(prompt, '', 'gemini-2.0-flash');
     if (!raw) return [];
     const jsonStr = raw.replace(/```json|```/g, '').trim();
     return JSON.parse(jsonStr);
@@ -183,7 +183,7 @@ Rules:
 - Examples: "Still planning on that morning run?", "Any progress on speaking up at meetings?"`;
 
   try {
-    const raw = await callGemini(prompt, '', 'gemini-1.5-flash');
+    const raw = await callGemini(prompt, '', 'gemini-2.0-flash');
     if (!raw) return [];
     const jsonStr = raw.replace(/```json|```/g, '').trim();
     return JSON.parse(jsonStr);
@@ -393,7 +393,7 @@ Return JSON only:
 If truly ambiguous, default to "personal".`;
 
   try {
-    const raw = await callGemini(prompt, '', 'gemini-1.5-flash');
+    const raw = await callGemini(prompt, '', 'gemini-2.0-flash');
     if (!raw) return { category: 'personal', confidence: 0.5 };
 
     const jsonStr = raw.replace(/```json|```/g, '').trim();


### PR DESCRIPTION
Bug fixes:
- Remove leftover setMode/setShowPrompts/setPromptMode calls in saveEntry (these state variables were removed during cleanup)
- Update all gemini-1.5-flash references to gemini-2.0-flash (1.5-flash is no longer available in the API)

Files changed:
- src/App.jsx: Remove undefined state setter calls
- src/config/ai.js: Update model config to use 2.0-flash
- src/services/prompts/index.js: Update 3 hardcoded model refs