### PR TITLE
Fix MoodHeatmap to use effectiveDate for backdated entries

### DIFF
--- a/src/components/entries/MoodHeatmap.jsx
+++ b/src/components/entries/MoodHeatmap.jsx
@@ -8,11 +8,16 @@ const MoodHeatmap = ({ entries, onDayClick }) => {
   }), []);
 
   const getDayData = (d) => {
-    const dayEntries = entries.filter(e =>
-      e.createdAt.getDate() === d.getDate() &&
-      e.createdAt.getMonth() === d.getMonth() &&
-      e.createdAt.getFullYear() === d.getFullYear()
-    );
+    const dayEntries = entries.filter(e => {
+      // Use effectiveDate if available (for backdated entries), otherwise createdAt
+      const dateField = e.effectiveDate || e.createdAt;
+      const entryDate = dateField instanceof Date
+        ? dateField
+        : dateField?.toDate?.() || new Date();
+      return entryDate.getDate() === d.getDate() &&
+        entryDate.getMonth() === d.getMonth() &&
+        entryDate.getFullYear() === d.getFullYear();
+    });
     const moodEntries = dayEntries.filter(e => e.entry_type !== 'task' && typeof e.analysis?.mood_score === 'number');
     const avgMood = moodEntries.length > 0
       ? moodEntries.reduce((sum, e) => sum + e.analysis.mood_score, 0) / moodEntries.length


### PR DESCRIPTION
The heatmap was using createdAt directly, so backdated entries weren't appearing on the correct day. Now uses effectiveDate if available, falling back to createdAt for older entries.

This ensures:
- Backdated entries show on the intended day in heatmap
- Clicking a day shows the correct entries in DailySummaryModal
- Mood calculations use the effective date for proper attribution