### PR TITLE
Fix React error #31: comprehensive defensive rendering for legacy data

### DIFF
--- a/src/components/entries/EntryCard.jsx
+++ b/src/components/entries/EntryCard.jsx
@@ -276,10 +276,16 @@ const EntryCard = ({ entry, onDelete, onUpdate }) => {
             <Clipboard size={12} /> Tasks
           </div>
           <div className="space-y-1">
-            {entry.extracted_tasks.map((task, i) => {
+            {entry.extracted_tasks.map((rawTask, i) => {
+              // Handle both object tasks and legacy string tasks
+              const task = typeof rawTask === 'string'
+                ? { text: rawTask, completed: false, recurrence: null }
+                : rawTask;
+              const taskText = task?.text || (typeof rawTask === 'string' ? rawTask : JSON.stringify(rawTask));
+
               // For recurring tasks, check if waiting for next due date
-              const isWaitingForNextDue = task.recurrence && task.nextDueDate && new Date(task.nextDueDate) > new Date();
-              const displayAsCompleted = task.completed || isWaitingForNextDue;
+              const isWaitingForNextDue = task?.recurrence && task?.nextDueDate && new Date(task.nextDueDate) > new Date();
+              const displayAsCompleted = task?.completed || isWaitingForNextDue;
 
               // Helper to calculate next due date
               const calculateNextDueDate = (recurrence) => {
@@ -329,9 +335,9 @@ const EntryCard = ({ entry, onDelete, onUpdate }) => {
                     className="rounded border-warm-300 text-primary-600 focus:ring-primary-500"
                   />
                   <span className={displayAsCompleted ? 'line-through text-warm-400' : 'text-warm-700'}>
-                    {task.text}
+                    {taskText}
                   </span>
-                  {task.recurrence && (
+                  {task?.recurrence && (
                     <span className="badge-recurring">
                       <RefreshCw size={10} className="inline mr-1" />
                       {task.recurrence.description || task.recurrence.pattern}

--- a/src/components/screens/JournalScreen.jsx
+++ b/src/components/screens/JournalScreen.jsx
@@ -30,7 +30,11 @@ const JournalScreen = ({
       filtered = filtered.filter(e =>
         e.text?.toLowerCase().includes(query) ||
         e.title?.toLowerCase().includes(query) ||
-        e.tags?.some(t => t.toLowerCase().includes(query))
+        e.tags?.some(t => {
+          // Handle both string tags and object tags (legacy data)
+          const tagStr = typeof t === 'string' ? t : (t?.text || '');
+          return tagStr.toLowerCase().includes(query);
+        })
       );
     }
 

--- a/src/utils/entries.js
+++ b/src/utils/entries.js
@@ -9,7 +9,9 @@ export const sanitizeEntry = (id, data) => {
     id: id,
     text: safeString(data.text),
     category: safeString(data.category) || 'personal',
-    tags: Array.isArray(data.tags) ? data.tags : [],
+    tags: Array.isArray(data.tags)
+      ? data.tags.map(t => typeof t === 'string' ? t : (t?.text || safeString(t)))
+      : [],
     title: safeString(data.title) || safeString(data.analysis?.summary) || "Untitled Memory",
     analysis: data.analysis || { mood_score: 0.5 },
     analysisStatus: data.analysisStatus || 'complete',


### PR DESCRIPTION
- EntryCard: Handle both string and object tasks in extracted_tasks
- JournalScreen: Handle both string and object tags in search filter
- sanitizeEntry: Convert object tags to strings at load time
- DayDashboard: Already fixed in previous commit

These changes handle legacy Firestore data where:
- extracted_tasks might contain strings instead of {text, completed} objects
- tags might contain task objects instead of strings