### PR TITLE
Add dismissable goals feature

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -969,6 +969,7 @@ export default function App() {
           <GoalsProgress
             entries={entries}
             category={cat}
+            userId={user?.uid}
           />
         )}
 


### PR DESCRIPTION
Users can now dismiss goals from the dashboard by clicking the X button that appears on hover. Dismissed goals are stored per-category in Firestore at users/{uid}/preferences/dismissedGoals.

- Added dismiss button with hover reveal on goal cards
- Optimistic UI update with rollback on failure
- Persists dismissed goals to Firestore
- Filters dismissed goals from the goals list