### PR TITLE
Fix saving entries on mobile and browser loading

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,9 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+    <!-- Standard PWA meta tag (required for modern browsers) -->
+    <meta name="mobile-web-app-capable" content="yes" />
+    <!-- Apple-specific PWA meta tags (for Safari compatibility) -->
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <meta name="theme-color" content="#0f766e" />

--- a/src/hooks/useIOSMeta.js
+++ b/src/hooks/useIOSMeta.js
@@ -1,25 +1,49 @@
 import { useEffect } from 'react';
 
 /**
- * Hook to set iOS-specific meta tags for PWA support
+ * Helper to add a meta tag only if it doesn't already exist
+ */
+const addMetaTagIfMissing = (name, content) => {
+  // Check if the meta tag already exists in the document
+  const existing = document.querySelector(`meta[name="${name}"]`);
+  if (existing) {
+    return null; // Tag already exists, don't add duplicate
+  }
+
+  const meta = document.createElement('meta');
+  meta.name = name;
+  meta.content = content;
+  document.head.appendChild(meta);
+  return meta;
+};
+
+/**
+ * Hook to ensure iOS/PWA-specific meta tags are present
+ * These tags are typically already in index.html, but this hook
+ * ensures they exist for dynamically rendered scenarios (e.g., SSR hydration)
  */
 export const useIOSMeta = () => {
   useEffect(() => {
     if (typeof document === 'undefined') return;
 
-    const meta = document.createElement('meta');
-    meta.name = 'apple-mobile-web-app-capable';
-    meta.content = 'yes';
-    document.head.appendChild(meta);
+    // Add standard PWA capability tag (for modern browsers)
+    const mobileMeta = addMetaTagIfMissing('mobile-web-app-capable', 'yes');
 
-    const style = document.createElement('meta');
-    style.name = 'apple-mobile-web-app-status-bar-style';
-    style.content = 'black-translucent';
-    document.head.appendChild(style);
+    // Add Apple-specific tags (for Safari)
+    const appleMeta = addMetaTagIfMissing('apple-mobile-web-app-capable', 'yes');
+    const styleMeta = addMetaTagIfMissing('apple-mobile-web-app-status-bar-style', 'black-translucent');
 
+    // Cleanup only tags that were dynamically added by this hook
     return () => {
-      if (document.head.contains(meta)) document.head.removeChild(meta);
-      if (document.head.contains(style)) document.head.removeChild(style);
+      if (mobileMeta && document.head.contains(mobileMeta)) {
+        document.head.removeChild(mobileMeta);
+      }
+      if (appleMeta && document.head.contains(appleMeta)) {
+        document.head.removeChild(appleMeta);
+      }
+      if (styleMeta && document.head.contains(styleMeta)) {
+        document.head.removeChild(styleMeta);
+      }
     };
   }, []);
 };


### PR DESCRIPTION
- Add standard 'mobile-web-app-capable' meta tag for modern browser PWA support
- Fix useIOSMeta hook to prevent duplicate meta tags
- Add timeout (15s) for embedding generation to prevent hangs on slow mobile connections
- Add timeout (10s) for temporal detection for mobile reliability
- Improve error handling - entries now save even if embedding fails (backfilled later)
- Add more informative error messages for network and permission issues

The deprecation warning for 'apple-mobile-web-app-capable' is now resolved by including both the standard tag and the Apple-specific tag.