### PR TITLE
fix: Increase timeouts to support very long voice recordings

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -673,12 +673,15 @@ export const generateEmbedding = onCall(
 
 /**
  * Cloud Function: Transcribe audio using Whisper
+ * Supports recordings up to ~10 minutes (Whisper API limit is 25MB)
  */
 export const transcribeAudio = onCall(
   {
     secrets: [openaiApiKey],
     cors: true,
-    maxInstances: 5
+    maxInstances: 5,
+    timeoutSeconds: 540,  // 9 minutes (max allowed) for very long recordings
+    memory: '1GiB'        // More memory for large audio processing
   },
   async (request) => {
     if (!request.auth) {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -500,10 +500,10 @@ export default function App() {
     // Wrap embedding generation with timeout for mobile reliability
     let embedding = null;
     try {
-      // Set a 15-second timeout for embedding generation (mobile connections can be slow)
+      // Set a 60-second timeout for embedding generation (very long entries need more time)
       const embeddingPromise = generateEmbedding(finalTex);
       const timeoutPromise = new Promise((_, reject) =>
-        setTimeout(() => reject(new Error('Embedding timeout')), 15000)
+        setTimeout(() => reject(new Error('Embedding timeout')), 60000)
       );
       embedding = await Promise.race([embeddingPromise, timeoutPromise]);
     } catch (embeddingError) {
@@ -697,11 +697,11 @@ export default function App() {
     }
 
     // Detect temporal context (Phase 2)
-    // Add timeout for mobile reliability
+    // Add timeout for mobile reliability (45s for very long entries)
     try {
       const temporalPromise = detectTemporalContext(textInput);
       const timeoutPromise = new Promise((_, reject) =>
-        setTimeout(() => reject(new Error('Temporal detection timeout')), 10000)
+        setTimeout(() => reject(new Error('Temporal detection timeout')), 45000)
       );
       const temporal = await Promise.race([temporalPromise, timeoutPromise]);
       console.log('Temporal detection result:', {


### PR DESCRIPTION
- Cloud Function transcribeAudio: 540s timeout (max), 1GiB memory
- Client embedding timeout: 60s (was 15s)
- Client temporal detection timeout: 45s (was 10s)

Supports recordings up to ~10 minutes (Whisper API limit is 25MB).