### PR TITLE
fix: Improve mobile reliability for long voice recordings

### DIFF
--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -2,3 +2,4 @@ export { useNotifications } from './useNotifications';
 export { useIOSMeta } from './useIOSMeta';
 export { useNetworkStatus } from './useNetworkStatus';
 export { useDashboardMode } from './useDashboardMode';
+export { useWakeLock } from './useWakeLock';

--- a/src/hooks/useWakeLock.js
+++ b/src/hooks/useWakeLock.js
@@ -1,0 +1,77 @@
+import { useState, useCallback, useRef, useEffect } from 'react';
+
+/**
+ * Hook to manage Screen Wake Lock API
+ * Prevents the device from dimming/locking the screen during long operations
+ * This helps prevent iOS Safari from killing pending network requests
+ */
+export const useWakeLock = () => {
+  const [isLocked, setIsLocked] = useState(false);
+  const wakeLockRef = useRef(null);
+
+  // Request wake lock
+  const requestWakeLock = useCallback(async () => {
+    // Check if Wake Lock API is supported
+    if (!('wakeLock' in navigator)) {
+      console.log('Wake Lock API not supported');
+      return false;
+    }
+
+    try {
+      wakeLockRef.current = await navigator.wakeLock.request('screen');
+      setIsLocked(true);
+
+      // Listen for wake lock release (e.g., when tab becomes hidden)
+      wakeLockRef.current.addEventListener('release', () => {
+        console.log('Wake lock released');
+        setIsLocked(false);
+      });
+
+      console.log('Wake lock acquired');
+      return true;
+    } catch (err) {
+      console.error('Failed to acquire wake lock:', err);
+      return false;
+    }
+  }, []);
+
+  // Release wake lock
+  const releaseWakeLock = useCallback(async () => {
+    if (wakeLockRef.current) {
+      try {
+        await wakeLockRef.current.release();
+        wakeLockRef.current = null;
+        setIsLocked(false);
+        console.log('Wake lock released manually');
+      } catch (err) {
+        console.error('Failed to release wake lock:', err);
+      }
+    }
+  }, []);
+
+  // Re-acquire wake lock when page becomes visible again
+  useEffect(() => {
+    const handleVisibilityChange = async () => {
+      if (document.visibilityState === 'visible' && isLocked && !wakeLockRef.current) {
+        // Page became visible again, try to re-acquire wake lock
+        await requestWakeLock();
+      }
+    };
+
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+    return () => {
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+    };
+  }, [isLocked, requestWakeLock]);
+
+  // Cleanup on unmount
+  useEffect(() => {
+    return () => {
+      if (wakeLockRef.current) {
+        wakeLockRef.current.release().catch(() => {});
+      }
+    };
+  }, []);
+
+  return { isLocked, requestWakeLock, releaseWakeLock };
+};

--- a/src/services/ai/transcription.js
+++ b/src/services/ai/transcription.js
@@ -1,37 +1,96 @@
 import { transcribeAudioFn } from '../../config';
 
 /**
+ * Sleep helper for retry backoff
+ */
+const sleep = (ms) => new Promise(resolve => setTimeout(resolve, ms));
+
+/**
+ * Check if an error is retryable (network issues, timeouts)
+ */
+const isRetryableError = (error) => {
+  const message = error?.message?.toLowerCase() || '';
+  const code = error?.code?.toLowerCase() || '';
+
+  return (
+    message.includes('network') ||
+    message.includes('timeout') ||
+    message.includes('aborted') ||
+    message.includes('failed to fetch') ||
+    message.includes('connection') ||
+    code.includes('unavailable') ||
+    code.includes('deadline-exceeded') ||
+    code === 'internal'
+  );
+};
+
+/**
  * Transcribe audio using Cloud Function (Whisper API)
+ * Includes retry logic with exponential backoff for mobile reliability
  * @param {string} base64 - Base64 encoded audio
  * @param {string} mimeType - MIME type of the audio
+ * @param {number} maxRetries - Maximum number of retry attempts (default: 3)
  * @returns {Promise<string>} - Transcription text or error code
  */
-export const transcribeAudio = async (base64, mimeType) => {
-  try {
-    console.log('Whisper transcription request (via Cloud Function):', {
-      mimeType,
-      model: 'whisper-1'
-    });
+export const transcribeAudio = async (base64, mimeType, maxRetries = 3) => {
+  let lastError = null;
 
-    const result = await transcribeAudioFn({ base64, mimeType });
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    try {
+      if (attempt > 0) {
+        // Exponential backoff: 2s, 4s, 8s
+        const backoffMs = Math.pow(2, attempt) * 1000;
+        console.log(`Transcription retry attempt ${attempt}/${maxRetries} after ${backoffMs}ms backoff`);
+        await sleep(backoffMs);
+      }
 
-    // Check for error response
-    if (result.data?.error) {
-      console.error('Transcription error:', result.data.error);
-      return result.data.error;
+      console.log('Whisper transcription request (via Cloud Function):', {
+        mimeType,
+        model: 'whisper-1',
+        attempt: attempt + 1,
+        maxRetries: maxRetries + 1
+      });
+
+      const result = await transcribeAudioFn({ base64, mimeType });
+
+      // Check for error response
+      if (result.data?.error) {
+        const errorCode = result.data.error;
+        console.error('Transcription error:', errorCode);
+
+        // Don't retry non-retryable errors (rate limit, auth, bad request)
+        if (errorCode === 'API_RATE_LIMIT' || errorCode === 'API_AUTH_ERROR' || errorCode === 'API_BAD_REQUEST') {
+          return errorCode;
+        }
+
+        // For other errors, continue to next retry
+        lastError = new Error(errorCode);
+        continue;
+      }
+
+      const transcript = result.data?.transcript;
+
+      if (!transcript) {
+        console.error('Transcription returned no content');
+        lastError = new Error('API_NO_CONTENT');
+        continue;
+      }
+
+      console.log('Whisper transcription result:', transcript);
+      return transcript;
+    } catch (e) {
+      console.error(`Whisper API exception (attempt ${attempt + 1}):`, e);
+      lastError = e;
+
+      // Only retry on network-related errors
+      if (!isRetryableError(e)) {
+        console.log('Non-retryable error, stopping retry attempts');
+        break;
+      }
     }
-
-    const transcript = result.data?.transcript;
-
-    if (!transcript) {
-      console.error('Transcription returned no content');
-      return 'API_NO_CONTENT';
-    }
-
-    console.log('Whisper transcription result:', transcript);
-    return transcript;
-  } catch (e) {
-    console.error('Whisper API exception:', e);
-    return 'API_EXCEPTION';
   }
+
+  // All retries exhausted
+  console.error('All transcription attempts failed:', lastError);
+  return 'API_EXCEPTION';
 };


### PR DESCRIPTION
This commit addresses issues where ~3 minute voice recordings were failing to save on mobile devices:

1. Add retry logic with exponential backoff to transcription service
   - Retries up to 3 times on network errors (2s, 4s, 8s backoff)
   - Non-retryable errors (rate limit, auth, bad request) fail fast

2. Fix stale closure issues in VoiceRecorder and EntryBar
   - Use refs to capture latest callback during long recordings
   - Prevents issues when React re-renders during 3+ min recordings

3. Add Screen Wake Lock API support
   - Prevents iOS Safari from killing requests during transcription
   - Auto-reacquires lock when page visibility changes

4. Add local audio backup before transcription
   - Saves audio to localStorage before upload attempt
   - Prevents complete data loss on network failures
   - Auto-cleanup of stale backups (>24 hours) on app startup

5. Improve error messages for mobile users
   - More specific messages for different failure modes
   - Inform users when audio is backed up locally