### PR TITLE
fix: Externalize iOS-only health plugin from web builds

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -3,4 +3,16 @@ import react from '@vitejs/plugin-react';
 
 export default defineConfig({
   plugins: [react()],
+  build: {
+    rollupOptions: {
+      // Don't bundle iOS-only plugins for web builds
+      external: [
+        '@flomentumsolutions/capacitor-health-extended'
+      ]
+    }
+  },
+  // Handle external modules during dev
+  optimizeDeps: {
+    exclude: ['@flomentumsolutions/capacitor-health-extended']
+  }
 });


### PR DESCRIPTION
Vite/Rollup was trying to bundle @flomentumsolutions/capacitor-health-extended for web deployments even though the plugin is only used on iOS. Added the plugin to rollupOptions.external and optimizeDeps.exclude to prevent build failures when deploying to web.