### PR TITLE
fix: Also externalize Google Fit plugin from web builds

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -8,7 +8,8 @@ export default defineConfig({
       // Don't bundle native-only plugins for web builds
       external: [
         '@flomentumsolutions/capacitor-health-extended',
-        'capacitor-google-fit'
+        'capacitor-google-fit',
+        '@nickmjones/capacitor-healthkit'
       ]
     }
   },
@@ -16,7 +17,8 @@ export default defineConfig({
   optimizeDeps: {
     exclude: [
       '@flomentumsolutions/capacitor-health-extended',
-      'capacitor-google-fit'
+      'capacitor-google-fit',
+      '@nickmjones/capacitor-healthkit'
     ]
   }
 });


### PR DESCRIPTION
Added capacitor-google-fit to rollupOptions.external and optimizeDeps.exclude to prevent build failures when deploying to web, same as the HealthKit plugin.