### PR TITLE
refactor: Prioritize validation over pattern insights in popup

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -886,13 +886,20 @@ export default function App() {
             });
 
             // Show insights popup if there's meaningful content to display
-            // Only for non-task entries with insights, CBT/ACT analysis, or celebrations
-            const hasInsight = insight?.found && insight?.message;
-            const hasCBT = analysis?.cbt_breakdown?.perspective;
+            // Priority: validation > therapeutic tools > pattern insights
+            const hasValidation = analysis?.cbt_breakdown?.validation ||
+                                 analysis?.vent_support?.validation;
+            const hasCBTTherapeutic = analysis?.cbt_breakdown?.perspective;
             const hasACT = analysis?.act_analysis?.defusion_phrase;
             const hasCelebration = analysis?.celebration?.affirmation;
+            const hasVentCooldown = analysis?.vent_support?.cooldown;
+            // Only show pattern insights if they're meaningful (not generic encouragement)
+            const hasUsefulInsight = insight?.found && insight?.message &&
+                                    insight?.type !== 'encouragement';
+
             const shouldShowPopup = classification.entry_type !== 'task' &&
-                                   (hasInsight || hasCBT || hasACT || hasCelebration);
+                                   (hasValidation || hasCBTTherapeutic || hasACT ||
+                                    hasCelebration || hasVentCooldown || hasUsefulInsight);
 
             if (shouldShowPopup) {
               // Small delay so the entry appears first, then show the insight

--- a/src/components/modals/EntryInsightsPopup.jsx
+++ b/src/components/modals/EntryInsightsPopup.jsx
@@ -1,15 +1,18 @@
 import React from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import {
-  X, Lightbulb, TrendingUp, Sparkles, AlertTriangle,
+  X, Heart, TrendingUp, Sparkles, AlertTriangle,
   RefreshCw, Target, Calendar, Brain, Wind, Compass, Footprints
 } from 'lucide-react';
 import { safeString, formatMentions } from '../../utils/string';
 
 /**
- * EntryInsightsPopup - Shows insights after entry submission
- * Displays contextual insight, CBT/ACT analysis, and celebrations
- * Persists until user dismisses it
+ * EntryInsightsPopup - Shows validation and insights after entry submission
+ *
+ * PRIORITY ORDER:
+ * 1. Validation first (empathetic acknowledgment)
+ * 2. Therapeutic tools (perspective, defusion) - only if helpful
+ * 3. Pattern insights last (only meaningful ones, skip generic encouragement)
  */
 const EntryInsightsPopup = ({
   isOpen,
@@ -23,14 +26,55 @@ const EntryInsightsPopup = ({
   const insight = contextualInsight;
   const cbt = analysis?.cbt_breakdown;
   const actAnalysis = analysis?.act_analysis;
+  const ventSupport = analysis?.vent_support;
   const celebration = analysis?.celebration;
   const framework = analysis?.framework || 'general';
 
-  // Don't show if there's nothing to display
-  const hasContent = insight?.found || cbt?.perspective || actAnalysis?.defusion_phrase || celebration?.affirmation;
+  // Get validation content based on framework
+  const getValidation = () => {
+    if (framework === 'support' && ventSupport?.validation) {
+      return ventSupport.validation;
+    }
+    if (framework === 'cbt' && cbt?.validation) {
+      return cbt.validation;
+    }
+    // ACT doesn't have explicit validation, but fusion_thought acknowledgment serves similar purpose
+    return null;
+  };
+
+  const validation = getValidation();
+
+  // Determine if pattern insight is worth showing
+  // Skip generic "encouragement" which can feel hollow/dismissive
+  const isInsightWorthShowing = () => {
+    if (!insight?.found || !insight?.message) return false;
+    // Skip encouragement type - often feels like toxic positivity
+    if (insight.type === 'encouragement') return false;
+    // Show meaningful pattern insights
+    return ['progress', 'streak', 'absence', 'warning', 'pattern', 'goal_check', 'cyclical', 'contradiction'].includes(insight.type);
+  };
+
+  const showPatternInsight = isInsightWorthShowing();
+
+  // Don't show popup if there's nothing meaningful to display
+  const hasValidation = !!validation;
+  const hasCelebration = framework === 'celebration' && celebration?.affirmation;
+  const hasTherapeutic = (framework === 'cbt' && cbt?.perspective) ||
+                         (framework === 'act' && actAnalysis?.defusion_phrase);
+  const hasContent = hasValidation || hasCelebration || hasTherapeutic || showPatternInsight;
+
   if (!hasContent) return null;
 
-  // Icon and color based on insight type
+  // Dynamic header based on content type
+  const getHeaderTitle = () => {
+    if (hasValidation || hasCelebration) return 'Heard';
+    if (framework === 'act') return 'A thought';
+    if (framework === 'cbt' && cbt?.perspective) return 'Perspective';
+    if (showPatternInsight) return 'Pattern';
+    return 'Reflection';
+  };
+
+  // Icon and color based on insight type (for pattern insights only)
   const getInsightStyle = (type) => {
     const styles = {
       progress: {
@@ -46,13 +90,6 @@ const EntryInsightsPopup = ({
         border: 'border-amber-200',
         iconColor: 'text-amber-600',
         textColor: 'text-amber-800'
-      },
-      encouragement: {
-        icon: Sparkles,
-        bg: 'bg-gradient-to-br from-purple-50 to-pink-50',
-        border: 'border-purple-200',
-        iconColor: 'text-purple-600',
-        textColor: 'text-purple-800'
       },
       absence: {
         icon: Target,
@@ -76,18 +113,15 @@ const EntryInsightsPopup = ({
         textColor: 'text-blue-800'
       },
       default: {
-        icon: Lightbulb,
-        bg: 'bg-gradient-to-br from-primary-50 to-secondary-50',
-        border: 'border-primary-200',
-        iconColor: 'text-primary-600',
-        textColor: 'text-primary-800'
+        icon: Brain,
+        bg: 'bg-gradient-to-br from-warm-50 to-warm-100',
+        border: 'border-warm-200',
+        iconColor: 'text-warm-600',
+        textColor: 'text-warm-700'
       }
     };
     return styles[type] || styles.default;
   };
-
-  const insightStyle = insight?.type ? getInsightStyle(insight.type) : getInsightStyle('default');
-  const InsightIcon = insightStyle.icon;
 
   return (
     <AnimatePresence>
@@ -97,7 +131,7 @@ const EntryInsightsPopup = ({
         animate={{ opacity: 1 }}
         exit={{ opacity: 0 }}
       >
-        {/* Subtle backdrop - less intrusive */}
+        {/* Subtle backdrop */}
         <motion.div
           className="absolute inset-0 bg-black/30 backdrop-blur-sm"
           initial={{ opacity: 0 }}
@@ -106,7 +140,7 @@ const EntryInsightsPopup = ({
           onClick={onClose}
         />
 
-        {/* Content card - slides up from bottom on mobile */}
+        {/* Content card */}
         <motion.div
           className="relative bg-white rounded-3xl shadow-soft-xl w-full max-w-md overflow-hidden"
           initial={{ opacity: 0, y: 50, scale: 0.95 }}
@@ -114,11 +148,11 @@ const EntryInsightsPopup = ({
           exit={{ opacity: 0, y: 50, scale: 0.95 }}
           transition={{ type: 'spring', damping: 25, stiffness: 300 }}
         >
-          {/* Header with close button */}
+          {/* Header */}
           <div className="flex items-center justify-between p-4 pb-0">
             <div className="flex items-center gap-2 text-warm-600">
-              <Lightbulb size={18} className="text-primary-500" />
-              <span className="font-display font-semibold text-sm">Insight</span>
+              <Heart size={18} className="text-primary-500" />
+              <span className="font-display font-semibold text-sm">{getHeaderTitle()}</span>
             </div>
             <motion.button
               onClick={onClose}
@@ -130,35 +164,28 @@ const EntryInsightsPopup = ({
             </motion.button>
           </div>
 
-          {/* Main content */}
+          {/* Main content - PRIORITY ORDER */}
           <div className="p-4 pt-3 space-y-4">
-            {/* Contextual Insight */}
-            {insight?.found && insight?.message && (
-              <motion.div
-                initial={{ opacity: 0, x: -10 }}
-                animate={{ opacity: 1, x: 0 }}
-                className={`p-4 rounded-2xl border ${insightStyle.bg} ${insightStyle.border}`}
-              >
-                <div className="flex gap-3">
-                  <InsightIcon size={20} className={`shrink-0 mt-0.5 ${insightStyle.iconColor}`} />
-                  <div className="flex-1">
-                    <div className={`text-[10px] font-display font-bold uppercase tracking-wider mb-1 ${insightStyle.iconColor}`}>
-                      {safeString(insight.type)}
-                    </div>
-                    <p className={`text-sm font-body leading-relaxed ${insightStyle.textColor}`}>
-                      {formatMentions(safeString(insight.message))}
-                    </p>
-                  </div>
-                </div>
-              </motion.div>
-            )}
 
-            {/* Celebration */}
-            {framework === 'celebration' && celebration?.affirmation && (
+            {/* 1. VALIDATION FIRST - Empathetic acknowledgment */}
+            {validation && (
               <motion.div
                 initial={{ opacity: 0, y: 10 }}
                 animate={{ opacity: 1, y: 0 }}
-                transition={{ delay: 0.1 }}
+                className="bg-gradient-to-br from-primary-50 to-warm-50 p-4 rounded-2xl border border-primary-100"
+              >
+                <p className="text-sm text-warm-700 font-body leading-relaxed italic">
+                  {validation}
+                </p>
+              </motion.div>
+            )}
+
+            {/* 2. CELEBRATION - For positive entries */}
+            {hasCelebration && (
+              <motion.div
+                initial={{ opacity: 0, y: 10 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ delay: validation ? 0.1 : 0 }}
                 className="bg-gradient-to-r from-green-50 to-emerald-50 p-4 rounded-2xl border border-green-100"
               >
                 <div className="flex items-center gap-2 text-green-700 font-display font-semibold text-xs uppercase mb-2">
@@ -171,22 +198,24 @@ const EntryInsightsPopup = ({
               </motion.div>
             )}
 
-            {/* CBT Perspective */}
+            {/* 3. THERAPEUTIC TOOLS - Only if mood warrants it */}
+
+            {/* CBT Perspective - cognitive reframe */}
             {framework === 'cbt' && cbt?.perspective && (
               <motion.div
                 initial={{ opacity: 0, y: 10 }}
                 animate={{ opacity: 1, y: 0 }}
                 transition={{ delay: 0.15 }}
-                className="bg-gradient-to-r from-primary-50 to-green-50 p-4 rounded-2xl border-l-4 border-primary-400"
+                className="bg-gradient-to-r from-blue-50 to-indigo-50 p-4 rounded-2xl border-l-4 border-blue-400"
               >
-                <div className="flex items-center gap-2 text-primary-600 font-display font-semibold text-xs uppercase mb-2">
-                  <Brain size={14} /> Perspective
+                <div className="flex items-center gap-2 text-blue-600 font-display font-semibold text-xs uppercase mb-2">
+                  <Brain size={14} /> Another way to see it
                 </div>
                 <p className="text-sm text-warm-700 font-body">{cbt.perspective}</p>
               </motion.div>
             )}
 
-            {/* ACT Defusion */}
+            {/* ACT Defusion - unhooking from thoughts */}
             {framework === 'act' && actAnalysis?.defusion_phrase && (
               <motion.div
                 initial={{ opacity: 0, y: 10 }}
@@ -194,43 +223,30 @@ const EntryInsightsPopup = ({
                 transition={{ delay: 0.15 }}
                 className="bg-teal-50 rounded-2xl p-4 border border-teal-100"
               >
-                <div className="flex items-center gap-2 mb-3">
-                  <Wind className="text-teal-600" size={16} />
-                  <span className="text-xs font-bold text-teal-700 uppercase">Defusion</span>
-                </div>
-
                 {actAnalysis.fusion_thought && (
-                  <div className="text-teal-900 text-sm mb-2">
-                    <span className="opacity-75">Instead of: </span>
-                    <span className="line-through decoration-teal-300">"{actAnalysis.fusion_thought}"</span>
+                  <div className="text-teal-900 text-sm mb-3">
+                    <span className="opacity-75">The thought: </span>
+                    <span className="italic">"{actAnalysis.fusion_thought}"</span>
                   </div>
                 )}
 
-                <div className="text-teal-800 font-medium text-sm bg-white/50 p-2 rounded-lg">
-                  Try: "{actAnalysis.defusion_phrase}"
+                <div className="text-teal-800 font-medium text-sm bg-white/50 p-3 rounded-lg">
+                  <span className="text-teal-600 text-xs uppercase font-semibold block mb-1">Try saying:</span>
+                  "{actAnalysis.defusion_phrase}"
                 </div>
 
                 {actAnalysis.values_context && (
                   <div className="mt-3 pt-3 border-t border-teal-100 flex items-center gap-2">
                     <Compass size={14} className="text-amber-600" />
                     <span className="text-xs text-amber-800">
-                      <span className="font-semibold">Value:</span> {actAnalysis.values_context}
+                      <span className="font-semibold">What matters here:</span> {actAnalysis.values_context}
                     </span>
-                  </div>
-                )}
-
-                {actAnalysis.committed_action && (
-                  <div className="mt-3 bg-amber-50 p-3 rounded-xl border border-amber-100">
-                    <div className="flex items-center gap-2 text-amber-700 font-display font-semibold text-xs uppercase mb-2">
-                      <Footprints size={14} /> Committed Action
-                    </div>
-                    <p className="text-sm text-amber-800 font-medium font-body">{actAnalysis.committed_action}</p>
                   </div>
                 )}
               </motion.div>
             )}
 
-            {/* Behavioral activation for CBT */}
+            {/* Behavioral activation - only for low mood */}
             {framework === 'cbt' && cbt?.behavioral_activation && (
               <motion.div
                 initial={{ opacity: 0, y: 10 }}
@@ -239,7 +255,7 @@ const EntryInsightsPopup = ({
                 className="bg-secondary-50 p-4 rounded-2xl border border-secondary-100"
               >
                 <div className="flex items-center gap-2 text-secondary-700 font-display font-semibold text-xs uppercase mb-2">
-                  <Footprints size={14} /> Try This (Under 5 min)
+                  <Footprints size={14} /> Something small you could try
                 </div>
                 <p className="text-sm text-secondary-800 font-medium font-body">{cbt.behavioral_activation.activity}</p>
                 {cbt.behavioral_activation.rationale && (
@@ -247,6 +263,62 @@ const EntryInsightsPopup = ({
                 )}
               </motion.div>
             )}
+
+            {/* ACT Committed Action */}
+            {framework === 'act' && actAnalysis?.committed_action && (
+              <motion.div
+                initial={{ opacity: 0, y: 10 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ delay: 0.2 }}
+                className="bg-amber-50 p-3 rounded-xl border border-amber-100"
+              >
+                <div className="flex items-center gap-2 text-amber-700 font-display font-semibold text-xs uppercase mb-2">
+                  <Footprints size={14} /> A values-aligned step
+                </div>
+                <p className="text-sm text-amber-800 font-medium font-body">{actAnalysis.committed_action}</p>
+              </motion.div>
+            )}
+
+            {/* Vent cooldown technique */}
+            {framework === 'support' && ventSupport?.cooldown && (
+              <motion.div
+                initial={{ opacity: 0, y: 10 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ delay: 0.15 }}
+                className="bg-primary-50 p-4 rounded-2xl border border-primary-100"
+              >
+                <div className="flex items-center gap-2 text-primary-700 font-display font-semibold text-xs uppercase mb-2">
+                  <Wind size={14} /> {ventSupport.cooldown.technique || 'Grounding'}
+                </div>
+                <p className="text-sm text-primary-800 font-body">{ventSupport.cooldown.instruction}</p>
+              </motion.div>
+            )}
+
+            {/* 4. PATTERN INSIGHT - Only if genuinely useful */}
+            {showPatternInsight && (() => {
+              const style = getInsightStyle(insight.type);
+              const InsightIcon = style.icon;
+              return (
+                <motion.div
+                  initial={{ opacity: 0, y: 10 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  transition={{ delay: 0.25 }}
+                  className={`p-4 rounded-2xl border ${style.bg} ${style.border}`}
+                >
+                  <div className="flex gap-3">
+                    <InsightIcon size={18} className={`shrink-0 mt-0.5 ${style.iconColor}`} />
+                    <div className="flex-1">
+                      <div className={`text-[10px] font-display font-bold uppercase tracking-wider mb-1 ${style.iconColor}`}>
+                        {safeString(insight.type).replace('_', ' ')}
+                      </div>
+                      <p className={`text-sm font-body leading-relaxed ${style.textColor}`}>
+                        {formatMentions(safeString(insight.message))}
+                      </p>
+                    </div>
+                  </div>
+                </motion.div>
+              );
+            })()}
           </div>
 
           {/* Dismiss button */}


### PR DESCRIPTION
- Show empathetic validation FIRST (cbt_breakdown.validation, vent_support.validation) before any pattern-based insights
- Skip generic "encouragement" type insights which can feel like toxic positivity for vulnerable entries
- Add vent support display with cooldown techniques
- Change header from "Insight" to context-aware titles ("Heard", "Perspective", "Pattern")
- Update trigger condition to show popup when validation exists, not just when pattern insights exist
- Restructure priority order: validation > celebration >
  therapeutic tools > pattern insights

This ensures entries about sensitive topics (body image, anxiety) get empathetic acknowledgment rather than hollow cheerleading.