### PR TITLE
feat: Add ACT acknowledgment field for validation-first responses

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -346,6 +346,7 @@ async function analyzeEntry(apiKey, text, entryType = 'reflection') {
 
       // INCLUDE IF FRAMEWORK == 'act'
       "act_analysis": {
+        "acknowledgment": "Warm, empathetic validation of the difficult feeling (1-2 sentences). Acknowledge the struggle is real and valid BEFORE offering any technique. E.g., 'Body image pressure in certain spaces is real and can feel overwhelming. It makes sense you'd feel uncomfortable in that environment.'",
         "fusion_thought": "The thought the user is 'fused' with - taking as absolute truth about themselves or reality",
         "defusion_technique": "labeling" | "visualization" | "thanking_mind",
         "defusion_phrase": "A phrase to create psychological distance. For labeling: 'I notice I'm having the thought that...'. For visualization: 'Imagine placing this thought on a leaf floating down a stream...'. For thanking_mind: 'Thanks, mind, for that thought...'",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -893,7 +893,8 @@ export default function App() {
             // Show insights popup if there's meaningful content to display
             // Priority: validation > therapeutic tools > pattern insights > encouragement fallback
             const hasValidation = analysis?.cbt_breakdown?.validation ||
-                                 analysis?.vent_support?.validation;
+                                 analysis?.vent_support?.validation ||
+                                 analysis?.act_analysis?.acknowledgment;
             const hasCBTTherapeutic = analysis?.cbt_breakdown?.perspective;
             const hasACT = analysis?.act_analysis?.defusion_phrase;
             const hasCelebration = analysis?.celebration?.affirmation;

--- a/src/components/modals/EntryInsightsPopup.jsx
+++ b/src/components/modals/EntryInsightsPopup.jsx
@@ -38,7 +38,9 @@ const EntryInsightsPopup = ({
     if (framework === 'cbt' && cbt?.validation) {
       return cbt.validation;
     }
-    // ACT doesn't have explicit validation, but fusion_thought acknowledgment serves similar purpose
+    if (framework === 'act' && actAnalysis?.acknowledgment) {
+      return actAnalysis.acknowledgment;
+    }
     return null;
   };
 


### PR DESCRIPTION
- Add 'acknowledgment' field to ACT analysis schema in Cloud Function with guidance to provide warm, empathetic validation BEFORE offering defusion techniques
- Update EntryInsightsPopup to recognize ACT acknowledgment as validation content, displaying it first in the popup
- Update App.jsx trigger condition to show popup when ACT acknowledgment exists

This ensures ACT framework entries (like body image, anxiety topics) receive empathetic validation before therapeutic techniques, matching the validation-first approach already used for CBT and vent entries.