### PR TITLE
feat: Improve goal extraction, popup UX, and surface follow-up questions

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -461,18 +461,32 @@ async function extractEnhancedContext(apiKey, text, recentEntriesContext = '') {
        - Main discussion themes/concerns
        - Examples: @topic:work_stress, @topic:relationship, @topic:health, @topic:finances
 
-    8. GOALS/INTENTIONS (@goal:description) - IMPORTANT: Extract these!
-       - Explicit goals stated in any form:
-         * "I want to...", "I need to...", "I'm going to...", "I plan to..."
-         * "My goal is...", "My goals are...", "My goals for this week..."
-         * "I aim to...", "I hope to...", "I'm trying to..."
-         * "Going to work out", "want to exercise", "planning to..."
-         * Any statement expressing a desired outcome, intention, or target
-       - Create SEPARATE tags for each distinct goal mentioned
-       - Be GENEROUS with goal extraction - if it sounds like an intention, tag it
-       - Examples: @goal:exercise_more, @goal:work_out_daily, @goal:do_pilates, @goal:eat_healthier
-       - Entry "My goals for this week are to work out every day and do Pilates on Thursday" should produce:
-         @goal:work_out_every_day AND @goal:do_pilates_thursday
+    8. GOALS/INTENTIONS (@goal:description) - BE SELECTIVE!
+       - ONLY extract TRUE GOALS: Ongoing aspirations requiring sustained effort over time
+       - A goal is something you work toward over weeks/months, not a one-off task
+
+       TRUE GOALS (extract these):
+         * Career/life direction: "find a new job", "get promoted", "start a business"
+         * Health/fitness patterns: "exercise regularly", "lose weight", "eat healthier", "work out daily"
+         * Personal development: "learn Spanish", "read more books", "meditate daily"
+         * Financial: "save money", "pay off debt", "build emergency fund"
+         * Relationship: "spend more quality time with family", "be a better listener"
+
+       NOT GOALS - DO NOT EXTRACT (these are tasks/events):
+         * One-off actions: "walk the dog", "check job listings", "prepare for interview"
+         * Specific event prep: "prepare Anthropic interview", "do Pilates on Thursday"
+         * Daily tasks: "walk Luna", "call mom", "check Databricks roles"
+         * Single occurrences: "go to Barry's class", "see a movie", "hang out with friend"
+
+       KEY DISTINCTION:
+         * "Do Pilates on Thursday" = TASK (specific one-time action) → DO NOT tag as goal
+         * "Do more Pilates" or "Add Pilates to my routine" = GOAL (ongoing intention) → Tag as @goal:do_more_pilates
+         * "Prepare for Anthropic interview" = TASK → DO NOT tag
+         * "Find a new job" or "Land a role in AI" = GOAL → Tag as @goal:find_new_job
+
+       Examples of what TO extract: @goal:find_new_job, @goal:exercise_regularly, @goal:eat_healthier, @goal:save_money
+
+       If unsure, ERR ON THE SIDE OF NOT extracting. Tasks should go in extracted_tasks, not goals.
 
     9. ONGOING SITUATIONS (@situation:description)
        - Multi-day events or circumstances

--- a/src/components/dashboard/shared/WeeklyDigest.jsx
+++ b/src/components/dashboard/shared/WeeklyDigest.jsx
@@ -108,11 +108,13 @@ const WeeklyDigest = ({ entries, category, userId }) => {
       .slice(0, 3)
       .map(([theme]) => theme);
 
-    // Find goals with progress
+    // Find goals with progress (clean up any tag prefixes)
     const goalsProgressed = [];
     weekEntries.forEach(e => {
       if (e.goal_update?.status === 'progress' || e.goal_update?.status === 'achieved') {
-        const goalName = e.goal_update.tag?.replace('@goal:', '').replace(/_/g, ' ');
+        // Clean up tag - remove @goal:, @situation:, or any @type: prefix
+        let goalName = e.goal_update.tag || '';
+        goalName = goalName.replace(/^@\w+:/i, '').replace(/_/g, ' ').trim();
         if (goalName && !goalsProgressed.includes(goalName)) {
           goalsProgressed.push(goalName);
         }
@@ -135,7 +137,9 @@ const WeeklyDigest = ({ entries, category, userId }) => {
     } else if (typeCounts.vent >= 2) {
       insight = 'You had a few venting moments this week. That release can be healthy.';
     } else if (goalsProgressed.length > 0) {
-      insight = `You made progress on ${goalsProgressed[0]}. Keep building that momentum!`;
+      // Title case the goal name for the message
+      const goalDisplay = goalsProgressed[0].split(' ').map(w => w.charAt(0).toUpperCase() + w.slice(1)).join(' ');
+      insight = `You made progress on ${goalDisplay}. Keep building that momentum!`;
     } else if (avgMood > 0.65) {
       insight = 'You had a good week overall. What contributed to that?';
     } else {
@@ -275,9 +279,9 @@ const WeeklyDigest = ({ entries, category, userId }) => {
                 <div className="flex items-start gap-2 p-2 bg-white/40 rounded-xl">
                   <Target size={14} className="text-primary-500 mt-0.5" />
                   <div>
-                    <p className="text-xs font-medium text-warm-700">Goals progressed</p>
+                    <p className="text-xs font-medium text-warm-700">Progress made</p>
                     <p className="text-xs text-warm-600 capitalize">
-                      {weekData.goalsProgressed.join(', ')}
+                      {weekData.goalsProgressed.map(g => g.charAt(0).toUpperCase() + g.slice(1)).join(', ')}
                     </p>
                   </div>
                 </div>

--- a/src/components/modals/EntryInsightsPopup.jsx
+++ b/src/components/modals/EntryInsightsPopup.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import {
   X, Heart, TrendingUp, Sparkles, AlertTriangle,
-  RefreshCw, Target, Calendar, Brain, Wind, Compass, Footprints
+  RefreshCw, Target, Calendar, Brain, Wind, Footprints, HelpCircle
 } from 'lucide-react';
 import { safeString, formatMentions } from '../../utils/string';
 
@@ -62,10 +62,13 @@ const EntryInsightsPopup = ({
   const needsFallback = !hasValidation && !hasCelebration && !hasTherapeutic && !hasVentCooldown && !isMeaningfulInsight;
   const showEncouragementAsFallback = needsFallback && hasEncouragement;
 
+  // Check for follow-up questions
+  const hasFollowUps = insight?.followUpQuestions?.length > 0;
+
   // Determine what to show
   const showPatternInsight = isMeaningfulInsight;
   const hasContent = hasValidation || hasCelebration || hasTherapeutic || hasVentCooldown ||
-                     showPatternInsight || showEncouragementAsFallback;
+                     showPatternInsight || showEncouragementAsFallback || hasFollowUps;
 
   if (!hasContent) return null;
 
@@ -147,7 +150,7 @@ const EntryInsightsPopup = ({
 
         {/* Content card */}
         <motion.div
-          className="relative bg-white rounded-3xl shadow-soft-xl w-full max-w-md overflow-hidden"
+          className="relative bg-white rounded-3xl shadow-soft-xl w-full max-w-sm overflow-hidden max-h-[75vh] flex flex-col"
           initial={{ opacity: 0, y: 50, scale: 0.95 }}
           animate={{ opacity: 1, y: 0, scale: 1 }}
           exit={{ opacity: 0, y: 50, scale: 0.95 }}
@@ -169,8 +172,8 @@ const EntryInsightsPopup = ({
             </motion.button>
           </div>
 
-          {/* Main content - PRIORITY ORDER */}
-          <div className="p-4 pt-3 space-y-4">
+          {/* Main content - PRIORITY ORDER (scrollable) */}
+          <div className="p-4 pt-3 space-y-4 overflow-y-auto flex-1">
 
             {/* 1. VALIDATION FIRST - Empathetic acknowledgment */}
             {validation && (
@@ -239,15 +242,6 @@ const EntryInsightsPopup = ({
                   <span className="text-teal-600 text-xs uppercase font-semibold block mb-1">Try saying:</span>
                   "{actAnalysis.defusion_phrase}"
                 </div>
-
-                {actAnalysis.values_context && (
-                  <div className="mt-3 pt-3 border-t border-teal-100 flex items-center gap-2">
-                    <Compass size={14} className="text-amber-600" />
-                    <span className="text-xs text-amber-800">
-                      <span className="font-semibold">What matters here:</span> {actAnalysis.values_context}
-                    </span>
-                  </div>
-                )}
               </motion.div>
             )}
 
@@ -338,10 +332,32 @@ const EntryInsightsPopup = ({
                 </p>
               </motion.div>
             )}
+
+            {/* 6. FOLLOW-UP QUESTIONS - Prompts for deeper reflection */}
+            {insight?.followUpQuestions?.length > 0 && (
+              <motion.div
+                initial={{ opacity: 0, y: 10 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ delay: 0.3 }}
+                className="bg-secondary-50 p-3 rounded-xl border border-secondary-100"
+              >
+                <div className="flex items-center gap-2 text-secondary-600 mb-2">
+                  <HelpCircle size={14} />
+                  <span className="text-xs font-semibold uppercase">To reflect on</span>
+                </div>
+                <ul className="space-y-1.5">
+                  {insight.followUpQuestions.slice(0, 2).map((question, idx) => (
+                    <li key={idx} className="text-sm text-secondary-700 font-body leading-relaxed">
+                      {question}
+                    </li>
+                  ))}
+                </ul>
+              </motion.div>
+            )}
           </div>
 
-          {/* Dismiss button */}
-          <div className="p-4 pt-0">
+          {/* Dismiss button (fixed at bottom) */}
+          <div className="p-4 pt-2 flex-shrink-0">
             <motion.button
               onClick={onClose}
               className="w-full py-3 rounded-2xl bg-warm-100 text-warm-600 font-semibold text-sm hover:bg-warm-200 transition-colors"


### PR DESCRIPTION
- Restrict goal extraction to true ongoing goals (not one-off tasks) Goals like "find new job" vs tasks like "walk Luna" or "prepare interview"
- Fix @Situation:job search formatting - clean up tag prefixes in display
- Remove "What matters here" section from ACT popup (felt dismissive)
- Make EntryInsightsPopup scrollable with smaller max-width (75vh, max-w-sm)
- Surface follow-up questions prominently in popup for deeper reflection