### PR TITLE
fix: Correct firebase import path in memoryGraph.js

### DIFF
--- a/src/services/memory/memoryGraph.js
+++ b/src/services/memory/memoryGraph.js
@@ -29,7 +29,7 @@ import {
   increment,
   Timestamp
 } from 'firebase/firestore';
-import { db } from '../../firebase';
+import { db } from '../../config/firebase';
 
 // Collection paths
 const APP_COLLECTION_ID = 'echo-vault-v5-fresh';


### PR DESCRIPTION
Changed from '../../firebase' to '../../config/firebase' to match the actual file location at src/config/firebase.js