### PR TITLE
fix: Export extractEntitiesByType from featureExtraction.js

### DIFF
--- a/src/services/patterns/advanced/featureExtraction.js
+++ b/src/services/patterns/advanced/featureExtraction.js
@@ -111,7 +111,7 @@ const countSelfReferences = (text) => {
 /**
  * Extract entities from tags by type
  */
-const extractEntitiesByType = (tags, prefix) => {
+export const extractEntitiesByType = (tags, prefix) => {
   if (!tags?.length) return [];
   return tags
     .filter(t => t.startsWith(prefix))


### PR DESCRIPTION
The function was defined but not exported as a named export, causing build failure when sequencePatterns.js tried to import it.