### PR TITLE
Review and integrate documentation fixes

### DIFF
--- a/src/hooks/useVoiceRelay.js
+++ b/src/hooks/useVoiceRelay.js
@@ -413,12 +413,36 @@ export const useVoiceRelay = () => {
     }
   }, [sessionId]);
 
-  // Cleanup on unmount
+  // Cleanup on unmount - FIX: Removed disconnect from deps to prevent unnecessary re-runs
+  // Cleanup logic is now inline to ensure it only runs on unmount
   useEffect(() => {
     return () => {
-      disconnect();
+      console.log('[useVoiceRelay] Cleanup on unmount, runId:post-fix');
+
+      // Inline cleanup (same as disconnect) to avoid dependency issues
+      cleanupTokenRefresh();
+
+      if (audioProcessorRef.current) {
+        audioProcessorRef.current.disconnect();
+        audioProcessorRef.current = null;
+      }
+
+      if (mediaStreamRef.current) {
+        mediaStreamRef.current.getTracks().forEach((track) => track.stop());
+        mediaStreamRef.current = null;
+      }
+
+      if (audioContextRef.current) {
+        audioContextRef.current.close();
+        audioContextRef.current = null;
+      }
+
+      if (wsRef.current) {
+        wsRef.current.close();
+        wsRef.current = null;
+      }
     };
-  }, [disconnect]);
+  }, []); // Empty deps - only run on unmount
 
   return {
     status,


### PR DESCRIPTION
Fix 1: Memory leak in useVoiceRelay
- Removed disconnect from useEffect dependencies
- Moved cleanup code inline to ensure it only runs on unmount
- Prevents unnecessary effect re-runs

Fix 2: Race condition in signal extraction version
- Use runTransaction to atomically read and increment signalExtractionVersion
- Prevents duplicate writes on concurrent edits

Fix 3: Audio cleanup not called in all paths
- Added streamRef to store media stream in VoiceRecorder
- Ensures cleanup on unmount, even if recording is active
- Added cleanup helper function for consistent cleanup across all paths

All fixes include runId:'post-fix' instrumentation for verification.