### PR TITLE
Fix FAB entry not setting reply context

### DIFF
--- a/src/components/zen/AppLayout.jsx
+++ b/src/components/zen/AppLayout.jsx
@@ -87,16 +87,17 @@ const AppLayout = ({
   const [entryMode, setEntryMode] = useState('text'); // 'voice' or 'text'
 
   // Direct handlers for FAB actions - show modal immediately
+  // NOTE: Don't set replyContext here - FAB entries are fresh, not responses to prompts
   const handleVoiceClick = () => {
     setEntryMode('voice');
+    setReplyContext?.(null); // Clear any existing reply context
     setShowEntryModal(true);
-    onVoiceEntry?.(); // Also call parent to set replyContext for EntryBar
   };
 
   const handleTextClick = () => {
     setEntryMode('text');
+    setReplyContext?.(null); // Clear any existing reply context
     setShowEntryModal(true);
-    onTextEntry?.(); // Also call parent to set replyContext for EntryBar
   };
 
   const handleCloseEntryModal = () => {


### PR DESCRIPTION
FAB entries (Voice/Text from + button) should be fresh entries, not responses to prompts. Removed the call to parent handlers that were setting replyContext to "Let it out - I'm here to listen."

Now FAB entries:
- Clear any existing replyContext
- Open the entry modal without "Responding to:" prompt
- Only dashboard prompts should set replyContext for actual responses