### PR TITLE
fix: Add @capacitor/browser dependency and handle web OAuth flow

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "@capacitor/android": "^8.0.0",
     "@capacitor/app": "^8.0.0",
+    "@capacitor/browser": "^8.0.0",
     "@capacitor/core": "^8.0.0",
     "@capacitor/geolocation": "^8.0.0",
     "@capacitor/haptics": "^8.0.0",

--- a/src/components/screens/HealthSettingsScreen.jsx
+++ b/src/components/screens/HealthSettingsScreen.jsx
@@ -27,7 +27,7 @@ import {
   ExternalLink,
   TrendingUp
 } from 'lucide-react';
-import { Browser } from '@capacitor/browser';
+import { Capacitor } from '@capacitor/core';
 
 import {
   getHealthDataStatus,
@@ -112,9 +112,16 @@ const HealthSettingsScreen = ({ onClose }) => {
     setWhoopConnecting(true);
     try {
       const authUrl = await initiateWhoopOAuth();
-      // Open Whoop authorization in browser
-      await Browser.open({ url: authUrl });
-      // Browser will redirect back via deep link when complete
+
+      // Open Whoop authorization - use Capacitor Browser on native, window.open on web
+      if (Capacitor.isNativePlatform()) {
+        const { Browser } = await import('@capacitor/browser');
+        await Browser.open({ url: authUrl });
+        // Browser will redirect back via deep link when complete
+      } else {
+        // On web, open in same window - OAuth callback will redirect back
+        window.location.href = authUrl;
+      }
     } catch (error) {
       console.error('Failed to initiate Whoop OAuth:', error);
       alert('Failed to connect to Whoop. Please try again.');


### PR DESCRIPTION
- Add @capacitor/browser to package.json dependencies
- Use dynamic import for Browser plugin on native platforms
- Fallback to window.location.href for web OAuth flow