### PR TITLE
fix: Use admin.firestore.Timestamp for Firestore timestamps

### DIFF
--- a/relay-server/src/auth/firebase.ts
+++ b/relay-server/src/auth/firebase.ts
@@ -488,4 +488,4 @@ const extractExcerpt = (text: string, queryWords: string[]): string => {
   return excerpt;
 };
 
-export { firestore, APP_COLLECTION_ID };
+export { admin, firestore, APP_COLLECTION_ID };

--- a/relay-server/src/services/whoop/tokenStore.ts
+++ b/relay-server/src/services/whoop/tokenStore.ts
@@ -5,7 +5,7 @@
  */
 
 import crypto from 'crypto';
-import { firestore, APP_COLLECTION_ID } from '../../auth/firebase.js';
+import { admin, firestore, APP_COLLECTION_ID } from '../../auth/firebase.js';
 import { config } from '../../config/index.js';
 
 export interface WhoopTokens {
@@ -110,9 +110,9 @@ export const storeTokens = async (
     refresh_token_encrypted: encrypted,
     refresh_token_iv: iv,
     refresh_token_tag: tag,
-    expires_at: firestore.Timestamp.fromDate(tokens.expiresAt),
+    expires_at: admin.firestore.Timestamp.fromDate(tokens.expiresAt),
     scopes: tokens.scopes,
-    linked_at: firestore.Timestamp.fromDate(tokens.linkedAt),
+    linked_at: admin.firestore.Timestamp.fromDate(tokens.linkedAt),
     whoop_user_id: tokens.whoopUserId,
   };
 
@@ -175,7 +175,7 @@ export const updateAccessToken = async (
 
   const updateData: Partial<StoredTokens> = {
     access_token: newAccessToken,
-    expires_at: firestore.Timestamp.fromDate(newExpiresAt),
+    expires_at: admin.firestore.Timestamp.fromDate(newExpiresAt),
   };
 
   // If a new refresh token is provided, encrypt and store it


### PR DESCRIPTION
The firestore export is the Firestore instance, not the namespace. Using admin.firestore.Timestamp.fromDate() is the correct pattern.