### PR TITLE
HOTFIX: import useState in App.jsx (app crashes on load for all users)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useMemo, useCallback } from 'react';
+import React, { useState, useEffect, useRef, useMemo, useCallback } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import {
   Mic, Loader2, LogIn, Activity, Brain, Share,

--- a/src/utils/__tests__/hookImports.test.js
+++ b/src/utils/__tests__/hookImports.test.js
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync, statSync } from 'fs';
+import { resolve, join } from 'path';
+
+/**
+ * Guard against "ReferenceError: <hook> is not defined" at runtime.
+ *
+ * A component that CALLS a React hook without importing it builds fine (esbuild
+ * doesn't error on undefined globals) and passes any test that doesn't render
+ * it — then throws in production. This exact bug shipped once when useState was
+ * used in App.jsx (migrated off useState to Zustand, so the import had been
+ * removed) and crashed the deployed app for every user on load. This test scans
+ * the source tree and fails if any file calls a hook it doesn't import.
+ */
+
+const SRC = resolve(__dirname, '../..');
+const REACT_HOOKS = [
+  'useState', 'useEffect', 'useCallback', 'useMemo', 'useRef',
+  'useContext', 'useReducer', 'useLayoutEffect', 'useImperativeHandle',
+];
+
+function collectSourceFiles(dir) {
+  const out = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    const st = statSync(full);
+    if (st.isDirectory()) {
+      if (entry === 'node_modules' || entry === '__tests__' || entry === 'test') continue;
+      out.push(...collectSourceFiles(full));
+    } else if (/\.(jsx?|tsx?)$/.test(entry)) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+function reactNamedImports(content) {
+  const names = new Set();
+  const re = /import\s+(?:React\s*,\s*)?\{([^}]*)\}\s*from\s*['"]react['"]/g;
+  let m;
+  while ((m = re.exec(content)) !== null) {
+    for (const raw of m[1].split(',')) {
+      const name = raw.trim().split(/\s+as\s+/)[0].trim();
+      if (name) names.add(name);
+    }
+  }
+  return names;
+}
+
+describe('React hook imports', () => {
+  const files = collectSourceFiles(SRC);
+
+  it('scans a meaningful number of source files', () => {
+    expect(files.length).toBeGreaterThan(50);
+  });
+
+  it('every file that calls a React hook imports it', () => {
+    const violations = [];
+    for (const file of files) {
+      const content = readFileSync(file, 'utf-8');
+      const named = reactNamedImports(content);
+      for (const hook of REACT_HOOKS) {
+        const callsHook = new RegExp(`\\b${hook}\\s*\\(`).test(content);
+        if (!callsHook) continue;
+        const imported = named.has(hook) || content.includes(`React.${hook}`);
+        if (!imported) {
+          violations.push(`${file.replace(SRC, 'src')} calls ${hook}() without importing it`);
+        }
+      }
+    }
+    expect(violations, `\n${violations.join('\n')}\n`).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Urgent — restores the deployed app

**Symptom:** every user sees the "Something went wrong" error boundary immediately on load.
**Cause:** `App.jsx` calls `useState` (added in #141 for the AI-consent modal) but never imports it — App.jsx had been migrated off `useState` to Zustand, so `useState` wasn't in its React import. Result: `ReferenceError: useState is not defined` thrown on load.
**Why CI/tests missed it:** esbuild doesn't error on undefined globals, and App.jsx has no render test.

## Fix
- Add `useState` to the `App.jsx` React import (one line).
- Add a static guard test (`hookImports.test.js`) that fails if any source file calls a React hook it doesn't import — verified it flags exactly this bug when the import is removed.

Suite green (738). Merge → hosting redeploys → app restored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)