### PR TITLE
Phase 3: capture-first home + What's New (stacked on Phase 2)

### DIFF
--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -17,7 +17,9 @@
 
 | Item | Status | Notes |
 |------|--------|-------|
-| **Phase 1: Fused Transcription + Durable Audio Vault** (branch: `feat/fused-transcription`) | 🔄 In Progress | Gemini fused transcription replaces whisper+regex+tone pipeline. Raw audio kept 7 days in vault. Removed dormant sw-audio.js. Ready for final branch review & merge. |
+| **Phase 1: Fused Transcription + Durable Audio Vault** (PR #145) | ✅ Merged & Deployed | Gemini fused transcription replaces whisper+regex+tone pipeline. Raw audio kept 7 days in vault. Removed dormant sw-audio.js. |
+| **Phase 2: Background Recording + Live Activity** (DRAFT PR #146) | 🔄 Code Done | Awaiting device/Xcode testing by PR owner. Waveform recording, background app refresh, Live Activity dynamic island timer. |
+| **Phase 3: Quick Capture Card + What's New** (branch: `feat/capture-first-reframe`) | 🔄 In Progress | Home screen bento quick-capture card, copy/paste support, What's New modal (v2.3.0). Status doc + decision log added. |
 | **Nexus 2.0 Insights Engine** | ✅ Complete | All 4 layers implemented (pattern detection, baselines, LLM synthesis, interventions) |
 | **Multi-Provider Authentication** | ✅ Complete | Google, Apple (iOS only), Email/Password with MFA support |
 | **App Store Readiness** | ✅ Complete | Crashlytics, Fastlane, testing, accessibility, performance optimization |
@@ -100,6 +102,8 @@
 | 2026-02-20 | Fraunces/DM Sans/Caveat font stack | Display font (headings), body font (UI), handwritten accent (sparingly). Caveat loaded with display=optional to prevent FOUT. | Performance issues on low-end devices |
 | 2026-07-10 | Fused Gemini transcription (transcribeEntry) replaces whisper+regex+tone 3-hop | Better cleanup (model hears audio), 1 call, ~3x cheaper | Gemini quality regressions or pricing change |
 | 2026-07-10 | Raw audio kept 7 days in local vault, never gated on cloud | Lost recordings are the #1 trust killer in voice apps | Storage pressure complaints |
+| 2026-07-10 | Quick Capture bento card is default-first on Home | Capture-first reframe: make voice journaling the primary UX entry point on launch | Engagement data shows users prefer other entry modes |
+| 2026-07-10 | Live Activity gated on background-recording go/no-go test | WKWebView may not record while device locked — do not ship a lying lock-screen timer | Go/no-go test passes and confirms recording works when locked |
 
 ---
 
@@ -136,6 +140,11 @@ Good ideas we're explicitly NOT doing now. Don't re-suggest these.
 | **Analysis not extracting themes/emotions** | Low | Cloud Function `analyzeEntry` prompt doesn't request themes/emotions fields. Would need prompt update. |
 | **Existing entries need platform flag** | Low | 140 existing entries don't have `createdOnPlatform` field. Could add migration to backfill `createdOnPlatform: 'unknown'` or `'web'`. |
 | **Audio vault (Phase 1) spec-vs-implementation deferrals** | Medium | Logged during final-review fix wave, deferred to Phase 2/3 consideration: (a) audio isn't timesliced to Filesystem during recording — kill-mid-recording still loses audio, since the vault only starts at recording stop; (b) failed uploads retry via the `PendingAudioBanner` UI, not through the `offlineManager`/`syncOrchestrator` durable queue; (c) no auto-created processing-state entry is written when a recording starts — the blocking alert-based failure flow is retained instead. |
+| **Existing customized dashboards don't auto-gain new widgets** | Low | Quick Capture card won't appear on home screens that users have customized. Requires a layout merge mechanism (compare stored layout vs new default). Acceptable to ship; users can reset to default or manually add. |
+| **Android capture surfaces deferred** | Medium | Android Quick Settings tile + notification surface for voice capture designed but not shipped. Viable, defer until Android user base matters. |
+| **App-Group widget data + dynamic content deferred** | Medium | Home screen widget can show static UI, but dynamic entry counts/streaks require capacitor-widget-bridge. Planned post-launch. |
+| **Replay-original audio UI deferred** | Low | Vault retains audio; UI to play original recording on entry detail screen not built. No blocker for launch; low user demand signal yet. |
+| **Entry restyle actions deferred** | Low | Planned "tighten/structure/expand" actions on entry cards. Depends on improved analysis backend; parked pending engagement data. |
 
 ### Investigation Notes: Health Context Not Captured
 

--- a/ios/App/App/CaptureIntents.swift
+++ b/ios/App/App/CaptureIntents.swift
@@ -1,6 +1,8 @@
+// Target: App (main). Requires iOS 17+ availability annotations because the App target deploys to iOS 15.
 import AppIntents
 import UIKit
 
+@available(iOS 17.0, *)
 struct StartBrainDumpIntent: AppIntent {
     static var title: LocalizedStringResource = "Start a Brain Dump"
     static var description = IntentDescription("Opens Engram and starts recording immediately.")
@@ -16,6 +18,7 @@ struct StartBrainDumpIntent: AppIntent {
     }
 }
 
+@available(iOS 17.0, *)
 struct EngramShortcuts: AppShortcutsProvider {
     static var appShortcuts: [AppShortcut] {
         AppShortcut(

--- a/ios/App/EngramWidget/EngramWidget.swift
+++ b/ios/App/EngramWidget/EngramWidget.swift
@@ -1,3 +1,4 @@
+// Target: EngramWidget extension ONLY (declares @main — never add to the App target). Set the extension's deployment target to iOS 17+ (containerBackground(for:) requires it).
 import WidgetKit
 import SwiftUI
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -356,6 +356,15 @@ export default function App() {
   // Deep link handler for OAuth callbacks (Whoop integration)
   useEffect(() => {
     const handleDeepLink = async (event) => {
+      // Capacitor iOS retains the launch URL and re-delivers it via appUrlOpen
+      // once the listener registers, causing double-processing (harmful for
+      // OAuth callbacks). Skip exactly one duplicate delivery of the URL we
+      // already consumed via getLaunchUrl(), then stop suppressing so a user
+      // can legitimately re-trigger the same URL later.
+      if (event.url && event.url === consumedLaunchUrlRef.current) {
+        consumedLaunchUrlRef.current = null;
+        return;
+      }
       try {
         const url = new URL(event.url);
         console.log('[Engram] Deep link received:', url.toString());
@@ -402,7 +411,10 @@ export default function App() {
     if (!launchUrlConsumedRef.current) {
       launchUrlConsumedRef.current = true;
       CapacitorApp.getLaunchUrl().then((result) => {
-        if (result?.url) handleDeepLink({ url: result.url });
+        if (result?.url) {
+          consumedLaunchUrlRef.current = result.url;
+          handleDeepLink({ url: result.url });
+        }
       }).catch(() => {});
     }
 
@@ -526,6 +538,9 @@ export default function App() {
 
   // Guard for deep-link cold start — launch URL consumed only once per app session
   const launchUrlConsumedRef = useRef(false);
+  // Tracks the specific URL delivered via getLaunchUrl() so we can dedupe the
+  // matching appUrlOpen delivery Capacitor iOS fires for the same cold-start URL.
+  const consumedLaunchUrlRef = useRef(null);
 
   // Background retrofit for enhanced context extraction
   const retrofitStarted = useRef(false);

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -405,15 +405,17 @@ export default function App() {
     // Listen for deep links
     const listener = CapacitorApp.addListener('appUrlOpen', handleDeepLink);
 
-    // Cold start: if the app was launched via a deep link, appUrlOpen never fires.
+    // Cold start: process the launch URL, then remember it so a subsequent
+    // retained appUrlOpen redelivery of the same URL is skipped exactly once.
+    // (Capacitor iOS retains the launch URL and redelivers it to the listener.)
     // Guard: this effect re-runs on showHealthSettings changes, but the launch URL
     // must only be consumed once per app session.
     if (!launchUrlConsumedRef.current) {
       launchUrlConsumedRef.current = true;
       CapacitorApp.getLaunchUrl().then((result) => {
         if (result?.url) {
-          consumedLaunchUrlRef.current = result.url;
           handleDeepLink({ url: result.url });
+          consumedLaunchUrlRef.current = result.url;
         }
       }).catch(() => {});
     }

--- a/src/components/shared/WhatsNewModal.jsx
+++ b/src/components/shared/WhatsNewModal.jsx
@@ -9,7 +9,7 @@ import { X, Heart, Sun, TrendingUp, Sparkles, CheckCircle, Lightbulb } from 'luc
  */
 
 // Increment this when adding new features to show the modal again
-const FEATURE_VERSION = '2.2.0';
+const FEATURE_VERSION = '2.3.0';
 const STORAGE_KEY = 'engram.lastSeenVersion';
 
 const WhatsNewModal = () => {
@@ -68,10 +68,10 @@ const WhatsNewModal = () => {
                   <span className="text-sm font-medium text-white/80">What's New</span>
                 </div>
                 <h2 className="font-display text-2xl font-bold">
-                  Health & Environment Insights
+                  Brain Dump Capture
                 </h2>
                 <p className="text-white/80 text-sm mt-1">
-                  Discover how your body and surroundings affect your mood
+                  Voice journaling, faster and smarter than ever
                 </p>
               </div>
             </div>
@@ -80,52 +80,52 @@ const WhatsNewModal = () => {
             <div className="p-6 space-y-4">
               {/* Feature 1 */}
               <div className="flex gap-4">
-                <div className="w-12 h-12 rounded-xl bg-red-100 dark:bg-red-900/30 flex items-center justify-center flex-shrink-0">
-                  <Heart size={24} className="text-red-500 dark:text-red-400" />
+                <div className="w-12 h-12 rounded-xl bg-honey-100 dark:bg-honey-900/30 flex items-center justify-center flex-shrink-0">
+                  <Sparkles size={24} className="text-honey-600 dark:text-honey-400" />
                 </div>
                 <div>
-                  <h3 className="font-semibold text-warm-800 dark:text-warm-200">Health-Mood Correlations</h3>
+                  <h3 className="font-semibold text-warm-800 dark:text-warm-200">Sharper voice transcription</h3>
                   <p className="text-sm text-warm-600 dark:text-warm-400">
-                    See how sleep, exercise, and recovery affect your emotional wellbeing with personalized insights.
+                    Smarter cleanup that keeps your meaning—no more mangled sentences
                   </p>
                 </div>
               </div>
 
               {/* Feature 2 */}
               <div className="flex gap-4">
-                <div className="w-12 h-12 rounded-xl bg-honey-100 dark:bg-honey-900/30 flex items-center justify-center flex-shrink-0">
-                  <Sun size={24} className="text-honey-600 dark:text-honey-400" />
+                <div className="w-12 h-12 rounded-xl bg-sage-100 dark:bg-sage-900/30 flex items-center justify-center flex-shrink-0">
+                  <CheckCircle size={24} className="text-sage-600 dark:text-sage-400" />
                 </div>
                 <div>
-                  <h3 className="font-semibold text-warm-800 dark:text-warm-200">Weather & Light Tracking</h3>
+                  <h3 className="font-semibold text-warm-800 dark:text-warm-200">Never lose a recording</h3>
                   <p className="text-sm text-warm-600 dark:text-warm-400">
-                    Automatic weather data with each entry. Backfill past entries in Settings → Health.
+                    Audio is saved on your device the moment you stop talking, with easy retry if transcription fails
                   </p>
                 </div>
               </div>
 
               {/* Feature 3 */}
               <div className="flex gap-4">
-                <div className="w-12 h-12 rounded-xl bg-lavender-100 dark:bg-lavender-900/30 flex items-center justify-center flex-shrink-0">
-                  <TrendingUp size={24} className="text-lavender-600 dark:text-lavender-400" />
+                <div className="w-12 h-12 rounded-xl bg-terra-100 dark:bg-terra-900/30 flex items-center justify-center flex-shrink-0">
+                  <TrendingUp size={24} className="text-terra-600 dark:text-terra-400" />
                 </div>
                 <div>
-                  <h3 className="font-semibold text-warm-800 dark:text-warm-200">Pattern Discovery</h3>
+                  <h3 className="font-semibold text-warm-800 dark:text-warm-200">Brain dump from your home screen</h3>
                   <p className="text-sm text-warm-600 dark:text-warm-400">
-                    View your patterns in the Insights tab—see what helps you feel your best.
+                    New Quick Capture card opens the mic in one tap
                   </p>
                 </div>
               </div>
 
               {/* Feature 4 */}
               <div className="flex gap-4">
-                <div className="w-12 h-12 rounded-xl bg-sage-100 dark:bg-sage-900/30 flex items-center justify-center flex-shrink-0">
-                  <Lightbulb size={24} className="text-sage-600 dark:text-sage-400" />
+                <div className="w-12 h-12 rounded-xl bg-lavender-100 dark:bg-lavender-900/30 flex items-center justify-center flex-shrink-0">
+                  <Lightbulb size={24} className="text-lavender-600 dark:text-lavender-400" />
                 </div>
                 <div>
-                  <h3 className="font-semibold text-warm-800 dark:text-warm-200">Smart Recommendations</h3>
+                  <h3 className="font-semibold text-warm-800 dark:text-warm-200">Coming to iOS: lock-screen widget + 'Hey Siri, start a brain dump'</h3>
                   <p className="text-sm text-warm-600 dark:text-warm-400">
-                    Get daily suggestions based on your health data and what's worked for you before.
+                    Voice capture wherever you are, even without unlocking your phone
                   </p>
                 </div>
               </div>

--- a/src/components/zen/AppLayout.jsx
+++ b/src/components/zen/AppLayout.jsx
@@ -25,6 +25,9 @@ import EntryBar from '../dashboard/EntryBar';
 // Stores
 import { useUiStore } from '../../stores';
 
+// Utils
+import { isCaptureRequestStale } from '../../utils/deepLinks';
+
 /**
  * AppLayout - Main application shell with Zen & Bento navigation
  *
@@ -104,6 +107,13 @@ const AppLayout = ({
 
   useEffect(() => {
     if (!captureRequest) return;
+    // A capture request can sit in the store for hours (e.g. a widget tap
+    // while signed out) — don't auto-start the mic on a stale request once
+    // the user finally opens the app.
+    if (isCaptureRequestStale(captureRequest)) {
+      clearCaptureRequest();
+      return;
+    }
     setEntryMode(captureRequest.mode);
     setShowEntryModal(true);
     clearCaptureRequest();

--- a/src/components/zen/widgets/QuickCaptureWidget.jsx
+++ b/src/components/zen/widgets/QuickCaptureWidget.jsx
@@ -1,0 +1,27 @@
+import { Mic } from 'lucide-react';
+import { useUiStore } from '../../../stores/uiStore';
+
+/**
+ * QuickCaptureWidget - Bento widget: the front door for brainstorm dumping.
+ * One tap requests voice capture; AppLayout reacts to `captureRequest` and
+ * opens the entry modal with voice auto-start.
+ */
+const QuickCaptureWidget = () => {
+  const requestCapture = useUiStore((s) => s.requestCapture);
+
+  return (
+    <button
+      onClick={() => requestCapture('voice')}
+      aria-label="Brain dump"
+      className="w-full h-full min-h-[120px] rounded-2xl bg-gradient-to-br from-honey-500 to-terra-500
+                 dark:from-honey-600 dark:to-terra-600 text-white shadow-soft-md
+                 flex flex-col items-center justify-center gap-2 active:scale-[0.98] transition-transform"
+    >
+      <Mic size={32} />
+      <span className="font-medium">Brain dump</span>
+      <span className="text-xs opacity-80">Tap and just talk</span>
+    </button>
+  );
+};
+
+export default QuickCaptureWidget;

--- a/src/components/zen/widgets/__tests__/QuickCaptureWidget.test.jsx
+++ b/src/components/zen/widgets/__tests__/QuickCaptureWidget.test.jsx
@@ -1,0 +1,22 @@
+/**
+ * Tests for QuickCaptureWidget — the Bento front door for voice capture.
+ *
+ * One tap should request voice capture via uiStore; AppLayout (elsewhere)
+ * reacts to `captureRequest` by opening the entry modal with voice auto-start.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { render, fireEvent, screen } from '@testing-library/react';
+import QuickCaptureWidget from '../QuickCaptureWidget';
+import { useUiStore } from '../../../../stores/uiStore';
+
+describe('QuickCaptureWidget', () => {
+  beforeEach(() => {
+    useUiStore.getState().clearCaptureRequest();
+  });
+
+  it('requests voice capture on tap', () => {
+    render(<QuickCaptureWidget />);
+    fireEvent.click(screen.getByRole('button', { name: /brain dump/i }));
+    expect(useUiStore.getState().captureRequest?.mode).toBe('voice');
+  });
+});

--- a/src/components/zen/widgets/index.js
+++ b/src/components/zen/widgets/index.js
@@ -7,6 +7,7 @@ export { default as GoalsWidget } from './GoalsWidget';
 export { default as MoodHeatmapWidget } from './MoodHeatmapWidget';
 export { default as StoriesWidget } from './StoriesWidget';
 export { default as NexusInsightsWidget } from './NexusInsightsWidget';
+export { default as QuickCaptureWidget } from './QuickCaptureWidget';
 
 // Widget type to component mapping
 import HeroWidget from './HeroWidget';
@@ -17,6 +18,7 @@ import GoalsWidget from './GoalsWidget';
 import MoodHeatmapWidget from './MoodHeatmapWidget';
 import StoriesWidget from './StoriesWidget';
 import NexusInsightsWidget from './NexusInsightsWidget';
+import QuickCaptureWidget from './QuickCaptureWidget';
 
 export const WIDGET_COMPONENTS = {
   hero: HeroWidget,
@@ -27,6 +29,7 @@ export const WIDGET_COMPONENTS = {
   heatmap: MoodHeatmapWidget,
   stories: StoriesWidget,
   nexus: NexusInsightsWidget,
+  capture: QuickCaptureWidget,
   // Future widgets
   trend: null,
   digest: null,

--- a/src/hooks/useDashboardLayout.js
+++ b/src/hooks/useDashboardLayout.js
@@ -8,6 +8,14 @@ import { APP_COLLECTION_ID } from '../config/constants';
  * Each widget has an id, type, default size, and display info
  */
 export const WIDGET_DEFINITIONS = {
+  quick_capture: {
+    id: 'quick_capture',
+    type: 'capture',
+    name: 'Quick Capture',
+    description: 'One tap to start a voice brain dump',
+    defaultSize: '2x1',
+    icon: 'Mic',
+  },
   hero_card: {
     id: 'hero_card',
     type: 'hero',
@@ -79,6 +87,7 @@ export const WIDGET_DEFINITIONS = {
  * Only shows Hero and Prompts cards by default
  */
 export const DEFAULT_DASHBOARD_LAYOUT = [
+  { id: 'quick_capture', type: 'capture', size: '2x1' },
   { id: 'hero_card', type: 'hero', size: '2x1' },
   { id: 'prompt_card', type: 'prompt', size: '2x1' },
 ];

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -124,7 +124,7 @@ const HomePage = ({
           animate={{ opacity: 1 }}
           transition={{ delay: 0.3 }}
         >
-          <p className="font-display font-medium mb-1">Welcome to your sanctuary</p>
+          <p className="font-display font-medium mb-1">What's on your mind?</p>
           <p className="text-hearth-600 text-xs">
             Tap the + button below to add your first entry
           </p>

--- a/src/utils/__tests__/deepLinks.test.js
+++ b/src/utils/__tests__/deepLinks.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { parseCaptureLink } from '../deepLinks';
+import { parseCaptureLink, isCaptureRequestStale, CAPTURE_REQUEST_MAX_AGE_MS } from '../deepLinks';
 
 describe('parseCaptureLink', () => {
   it('parses voice capture links', () => {
@@ -16,5 +16,22 @@ describe('parseCaptureLink', () => {
     expect(parseCaptureLink('engram://auth-success?provider=whoop')).toBeNull();
     expect(parseCaptureLink('https://example.com/capture')).toBeNull();
     expect(parseCaptureLink('not a url')).toBeNull();
+  });
+});
+
+describe('isCaptureRequestStale', () => {
+  it('is not stale for a fresh request', () => {
+    const now = Date.now();
+    expect(isCaptureRequestStale({ mode: 'voice', ts: now }, now)).toBe(false);
+  });
+  it('is stale for a request older than the max age', () => {
+    const now = Date.now();
+    const ts = now - (CAPTURE_REQUEST_MAX_AGE_MS + 1000);
+    expect(isCaptureRequestStale({ mode: 'voice', ts }, now)).toBe(true);
+  });
+  it('is stale for null/missing request or missing ts', () => {
+    const now = Date.now();
+    expect(isCaptureRequestStale(null, now)).toBe(true);
+    expect(isCaptureRequestStale({ mode: 'voice' }, now)).toBe(true);
   });
 });

--- a/src/utils/deepLinks.js
+++ b/src/utils/deepLinks.js
@@ -9,3 +9,10 @@ export function parseCaptureLink(urlString) {
     return null;
   }
 }
+
+export const CAPTURE_REQUEST_MAX_AGE_MS = 60_000;
+
+/** A capture request older than CAPTURE_REQUEST_MAX_AGE_MS must not auto-start the mic. */
+export function isCaptureRequestStale(request, now = Date.now()) {
+  return !request || typeof request.ts !== 'number' || now - request.ts > CAPTURE_REQUEST_MAX_AGE_MS;
+}


### PR DESCRIPTION
Implements Phase 3 code of docs/superpowers/plans/2026-07-10-brainstorm-capture.md (Tasks 11, 15 + final-review fixes). STACKED on #146 — retarget to main after #146 merges.

## Done (code, tested, reviewed)
- Quick Capture bento card (`quick_capture`), default-FIRST on Home for new users; taps `requestCapture('voice')` → entry modal with mic auto-start. Palette-compliant (honey→terra). Note: users with saved custom layouts must add it via the widget drawer (no layout-merge mechanism exists; logged follow-up).
- Neutral copy on capture surfaces ("Welcome to your sanctuary" → "What's on your mind?"); wellness/safety copy elsewhere untouched.
- What's New 2.3.0 (transcription, recording durability, Quick Capture, iOS widget teaser).
- Final-review hardening: stale capture requests (>60s, e.g. widget tap while signed out) no longer hot-start the mic on a later login; cold-start launch-URL handling processes-then-dedupes against Capacitor's retained appUrlOpen redelivery; Swift sources annotated @available(iOS 17) with target headers.

## Remaining (device-gated, plan Tasks 12-14)
- Background-recording go/no-go (Task 12) → gates Live Activity (Task 13)
- Control Center control (Task 14, iOS 18, reuses StartBrainDumpIntent)

719/719 tests green, build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)