### PR TITLE
Background capture: Shortcuts → inbox → processed on next open (stacked)

### DIFF
--- a/ios/App/App/CaptureIntents.swift
+++ b/ios/App/App/CaptureIntents.swift
@@ -45,14 +45,24 @@ struct SaveBrainDumpIntent: AppIntent {
         let id = UUID().uuidString
         // IntentFile.data is the stored (already-loaded) Data for the file;
         // no async accessor needed here.
+        //
+        // Order matters: write the .m4a FIRST, then the .json sidecar LAST,
+        // and use .atomic writes for both so a crash mid-write never leaves
+        // a half-written file on disk. sweepCaptureInbox() (JS side) treats
+        // a sidecar-less .m4a as processable (falls back to default
+        // capturedAt/mime), so a crash after the m4a write but before the
+        // json write just loses the capture-time metadata for that one
+        // recording — harmless. The reverse order would be worse: a crash
+        // after a json-first write but before the m4a write leaves a
+        // dangling sidecar with no audio to ever pair it with.
         let data = audio.data
-        try data.write(to: inbox.appendingPathComponent("\(id).m4a"))
+        try data.write(to: inbox.appendingPathComponent("\(id).m4a"), options: .atomic)
         let meta: [String: Any] = [
             "capturedAt": ISO8601DateFormatter().string(from: Date()),
             "mime": "audio/mp4"
         ]
         let metaData = try JSONSerialization.data(withJSONObject: meta)
-        try metaData.write(to: inbox.appendingPathComponent("\(id).json"))
+        try metaData.write(to: inbox.appendingPathComponent("\(id).json"), options: .atomic)
         return .result()
     }
 }

--- a/ios/App/App/CaptureIntents.swift
+++ b/ios/App/App/CaptureIntents.swift
@@ -29,7 +29,8 @@ struct SaveBrainDumpIntent: AppIntent {
     static var description = IntentDescription("Saves a recording into Engram for transcription on next open. Works without opening the app.")
     static var openAppWhenRun: Bool = false
 
-    @Parameter(title: "Audio", supportedContentTypes: [.audio, .mpeg4Audio])
+    // Note: supportedContentTypes on @Parameter requires iOS 18 — omitted for iOS 17 compat.
+    @Parameter(title: "Audio")
     var audio: IntentFile
 
     func perform() async throws -> some IntentResult {

--- a/ios/App/App/CaptureIntents.swift
+++ b/ios/App/App/CaptureIntents.swift
@@ -18,6 +18,45 @@ struct StartBrainDumpIntent: AppIntent {
     }
 }
 
+// Written by the iOS Shortcuts "Record Audio" action piping into this intent.
+// Deliberately openAppWhenRun = false: the whole point is that Engram never
+// opens. The recording lands in the inbox and is swept into the transcription
+// pipeline on next launch/foreground (see src/services/audio/captureInbox.js),
+// with the entry timestamped at capture time via the capturedAt sidecar field.
+@available(iOS 17.0, *)
+struct SaveBrainDumpIntent: AppIntent {
+    static var title: LocalizedStringResource = "Save Brain Dump Audio"
+    static var description = IntentDescription("Saves a recording into Engram for transcription on next open. Works without opening the app.")
+    static var openAppWhenRun: Bool = false
+
+    @Parameter(title: "Audio", supportedContentTypes: [.audio, .mpeg4Audio])
+    var audio: IntentFile
+
+    func perform() async throws -> some IntentResult {
+        let fm = FileManager.default
+        guard let docs = fm.urls(for: .documentDirectory, in: .userDomainMask).first else {
+            throw NSError(domain: "Engram", code: 1)
+        }
+        // Capacitor's Directory.Data maps to the Documents directory on iOS,
+        // so writing here makes the file visible to Filesystem.readdir() from
+        // the JS side without any native plugin bridging.
+        let inbox = docs.appendingPathComponent("engram-inbox", isDirectory: true)
+        try fm.createDirectory(at: inbox, withIntermediateDirectories: true)
+        let id = UUID().uuidString
+        // IntentFile.data is the stored (already-loaded) Data for the file;
+        // no async accessor needed here.
+        let data = audio.data
+        try data.write(to: inbox.appendingPathComponent("\(id).m4a"))
+        let meta: [String: Any] = [
+            "capturedAt": ISO8601DateFormatter().string(from: Date()),
+            "mime": "audio/mp4"
+        ]
+        let metaData = try JSONSerialization.data(withJSONObject: meta)
+        try metaData.write(to: inbox.appendingPathComponent("\(id).json"))
+        return .result()
+    }
+}
+
 @available(iOS 17.0, *)
 struct EngramShortcuts: AppShortcutsProvider {
     static var appShortcuts: [AppShortcut] {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -550,7 +550,10 @@ export default function App() {
         // sweepCaptureInbox before we got here, so unprocessed items just sit
         // as recoverable orphans that PendingAudioBanner already knows how to
         // surface for manual retry.
-        if (useSafetyStore.getState().crisisModal) {
+        // Gate on pendingEntry as well: the modal can close into the crisis-
+        // resources screen while pendingEntry is still held (unresolved flow).
+        const safetyState = useSafetyStore.getState();
+        if (safetyState.crisisModal || safetyState.pendingEntry) {
           const remaining = items.length - (i + 1);
           console.log(`[captureInbox] pausing sweep — crisis flow open, ${remaining} items remain as recoverable orphans`);
           break;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -40,6 +40,7 @@ import { parseCaptureLink } from './utils/deepLinks';
 // Services
 import { generateEmbedding, findRelevantMemories, transcribeAudioWithTone, transcribeEntryFused } from './services/ai';
 import { audioVault } from './services/audio/audioVault';
+import { sweepCaptureInbox } from './services/audio/captureInbox';
 import {
   classifyEntry, analyzeEntry, generateInsight, extractEnhancedContext,
   performLocalAnalysis, getAnalysisStrategy
@@ -500,6 +501,58 @@ export default function App() {
     return cleanup;
   }, [user?.uid]);
 
+  // Background capture inbox: recordings written by the iOS Shortcuts
+  // "Record Audio" -> SaveBrainDumpIntent while Engram was never opened
+  // (see ios/App/App/CaptureIntents.swift + src/services/audio/captureInbox.js).
+  // Swept once on login and again every time the app returns to the
+  // foreground, since a recording can land in the inbox at any point while
+  // the app is backgrounded. handleAudioWrapper carries capturedAt through so
+  // the resulting entry is timestamped at capture time, not sweep time.
+  //
+  // Note: handleAudioWrapper returns false (no-op) if a save is already in
+  // flight (its `processing` reentrancy guard). sweepCaptureInbox has already
+  // vault-copied the recording by then, so it isn't lost — it just becomes an
+  // unlinked orphan that PendingAudioBanner already knows how to surface for
+  // manual retry, same as any other interrupted save.
+  useEffect(() => {
+    if (!user?.uid) return;
+    let cancelled = false;
+
+    const processCaptureInbox = async () => {
+      let items;
+      try {
+        items = await sweepCaptureInbox();
+      } catch (e) {
+        console.warn('[CaptureInbox] sweep failed:', e);
+        return;
+      }
+      if (cancelled || !items?.length) return;
+      console.log('[CaptureInbox] processing', items.length, 'background-captured recording(s)');
+      for (const item of items) {
+        if (cancelled) break;
+        try {
+          await handleAudioWrapper(item.base64, item.mime, {
+            existingRecordingId: item.recordingId,
+            capturedAt: item.capturedAt
+          });
+        } catch (e) {
+          console.warn('[CaptureInbox] failed to process item:', e);
+        }
+      }
+    };
+
+    processCaptureInbox();
+
+    const listenerPromise = CapacitorApp.addListener('appStateChange', ({ isActive }) => {
+      if (isActive) processCaptureInbox();
+    });
+
+    return () => {
+      cancelled = true;
+      listenerPromise.then(l => l.remove());
+    };
+  }, [user?.uid]);
+
   // Auth
   useEffect(() => {
     console.log('[Engram] Setting up auth listener...');
@@ -813,7 +866,8 @@ export default function App() {
         entry.safetyFlagged ?? true,
         safetyUserResponse,
         null,
-        entry.voiceTone ?? null
+        entry.voiceTone ?? null,
+        { capturedAt: entry.capturedAt }
       );
       // The recording (if this crisis entry came from voice) was deliberately
       // left unlinked in the vault until the entry actually existed — link it
@@ -847,8 +901,16 @@ export default function App() {
     await persistPendingEntry('support');
   }, [persistPendingEntry]);
 
-  const doSaveEntry = async (textInput, safetyFlagged = false, safetyUserResponse = null, temporalContext = null, voiceTone = null) => {
+  const doSaveEntry = async (textInput, safetyFlagged = false, safetyUserResponse = null, temporalContext = null, voiceTone = null, options = {}) => {
     if (!user) return;
+
+    // capturedAt (ISO string) is the sole exception to "always current date"
+    // below: it's set only for entries swept from the background-capture
+    // inbox (Shortcuts -> SaveBrainDumpIntent), where "now" is when the app
+    // happened to process the recording, not when the user actually spoke.
+    // Every downstream use of `now` in this function (createdAt, effectiveDate,
+    // the offline-queue path, signal extraction) picks this up for free.
+    const { capturedAt } = options;
 
     console.time('⏱️ TOTAL: Save entry to Firestore');
 
@@ -862,7 +924,8 @@ export default function App() {
     // TEMPORAL REDESIGN: Always use current date for effectiveDate.
     // Temporal attribution is now handled by signals, not by backdating entries.
     // effectiveDate is kept for backwards compatibility with old entries.
-    const now = new Date();
+    const parsedCapturedAt = capturedAt && !isNaN(Date.parse(capturedAt)) ? new Date(capturedAt) : null;
+    const now = parsedCapturedAt || new Date();
     const effectiveDate = now;  // Always current date - signals handle temporal attribution
 
     console.log('Saving entry with:', {
@@ -1020,7 +1083,7 @@ export default function App() {
         category: cat,
         analysisStatus: 'pending',
         embedding,
-        createdAt: Timestamp.now(),
+        createdAt: Timestamp.fromDate(now),
         effectiveDate: Timestamp.fromDate(effectiveDate),
         userId: user.uid,
         // Signal extraction version - increments on each edit for race condition handling
@@ -1420,7 +1483,7 @@ export default function App() {
   };
 
   const saveEntry = async (textInput, voiceTone = null, options = {}) => {
-    const { recordingId } = options;
+    const { recordingId, capturedAt } = options;
     if (!user) return;
     setProcessing(true);
     console.log('[SaveEntry] Starting save process, text length:', textInput.length, 'hasVoiceTone:', !!voiceTone);
@@ -1429,7 +1492,7 @@ export default function App() {
     const hasCrisis = checkCrisisKeywords(textInput);
     if (hasCrisis) {
       console.log('[SaveEntry] Crisis keywords detected, showing modal');
-      setPendingEntry({ text: textInput, safetyFlagged: true, voiceTone, recordingId });
+      setPendingEntry({ text: textInput, safetyFlagged: true, voiceTone, recordingId, capturedAt });
       setCrisisModal(true);
       setProcessing(false);
       return 'deferred';
@@ -1466,10 +1529,13 @@ export default function App() {
       }
 
       // Always save with current date - signals handle temporal attribution
-      return await doSaveEntry(textInput, false, null, temporal.detected ? temporal : null, voiceTone);
+      // (capturedAt is the one exception: a background-captured recording's
+      // entry is stamped at capture time, not at whenever the app next opened
+      // and swept it — see src/services/audio/captureInbox.js.)
+      return await doSaveEntry(textInput, false, null, temporal.detected ? temporal : null, voiceTone, { capturedAt });
     } catch (e) {
       console.error('Temporal detection failed, saving normally:', e);
-      return await doSaveEntry(textInput, false, null, null, voiceTone);
+      return await doSaveEntry(textInput, false, null, null, voiceTone, { capturedAt });
     }
   };
 
@@ -1520,7 +1586,7 @@ export default function App() {
   }, []);
 
   const handleAudioWrapper = async (base64, mime, options = {}) => {
-    const { existingRecordingId } = options;
+    const { existingRecordingId, capturedAt } = options;
     console.log('[Transcription] handleAudioWrapper called');
     console.log('[Transcription] Audio data received:', {
       base64Length: base64?.length || 0,
@@ -1634,7 +1700,7 @@ export default function App() {
 
       // Pass voice tone analysis to saveEntry
       console.log('[Transcription] Calling saveEntry with transcript length:', transcript.length, 'voiceTone:', !!toneAnalysis);
-      const saveResult = await saveEntry(transcript, toneAnalysis, { recordingId });
+      const saveResult = await saveEntry(transcript, toneAnalysis, { recordingId, capturedAt });
       console.log('[Transcription] saveEntry completed with result:', saveResult);
       // Only link (and thereby clear it from the recovery banner) once the
       // entry actually exists. When the crisis flow deferred the save,

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -528,8 +528,9 @@ export default function App() {
       }
       if (cancelled || !items?.length) return;
       console.log('[CaptureInbox] processing', items.length, 'background-captured recording(s)');
-      for (const item of items) {
+      for (let i = 0; i < items.length; i++) {
         if (cancelled) break;
+        const item = items[i];
         try {
           await handleAudioWrapper(item.base64, item.mime, {
             existingRecordingId: item.recordingId,
@@ -537,6 +538,22 @@ export default function App() {
           });
         } catch (e) {
           console.warn('[CaptureInbox] failed to process item:', e);
+        }
+        // Invariant: safetyStore's crisisModal/pendingEntry are single-slot —
+        // only one crisis flow can be "open" at a time. If the item we just
+        // processed tripped crisis detection, handleAudioWrapper already called
+        // startCrisisFlow() and populated that slot. If we kept looping and the
+        // *next* item also tripped crisis detection, its startCrisisFlow() call
+        // would silently overwrite this item's modal/pendingEntry before the
+        // user ever saw it. So: stop sweeping the instant a crisis flow opens.
+        // Nothing is lost by pausing — every item was already vault-copied by
+        // sweepCaptureInbox before we got here, so unprocessed items just sit
+        // as recoverable orphans that PendingAudioBanner already knows how to
+        // surface for manual retry.
+        if (useSafetyStore.getState().crisisModal) {
+          const remaining = items.length - (i + 1);
+          console.log(`[captureInbox] pausing sweep — crisis flow open, ${remaining} items remain as recoverable orphans`);
+          break;
         }
       }
     };

--- a/src/services/audio/__tests__/audioVault.test.js
+++ b/src/services/audio/__tests__/audioVault.test.js
@@ -65,6 +65,20 @@ describe('audioVault', () => {
     expect(await audioVault.getRecording(freshId)).not.toBeNull();
   });
 
+  it('saveRecording honors options.createdAt (e.g. a background-capture timestamp)', async () => {
+    const capturedAt = Date.parse('2026-01-01T00:00:00.000Z');
+    const id = await audioVault.saveRecording('QUJD', 'audio/webm', { createdAt: capturedAt });
+    const rec = await audioVault.getRecording(id);
+    expect(rec.createdAt).toBe(capturedAt);
+  });
+
+  it('saveRecording defaults createdAt to now when options are omitted', async () => {
+    const before = Date.now();
+    const id = await audioVault.saveRecording('QUJD', 'audio/webm');
+    const rec = await audioVault.getRecording(id);
+    expect(rec.createdAt).toBeGreaterThanOrEqual(before);
+  });
+
   it('never throws when storage fails — returns null id', async () => {
     const spy = vi.spyOn(Filesystem, 'writeFile').mockRejectedValueOnce(new Error('disk full'));
     const id = await audioVault.saveRecording('QUJD', 'audio/webm');

--- a/src/services/audio/__tests__/audioVault.test.js
+++ b/src/services/audio/__tests__/audioVault.test.js
@@ -53,9 +53,11 @@ describe('audioVault', () => {
 
   it('cleanupExpired deletes recordings older than 7 days but keeps fresh ones', async () => {
     const oldId = await audioVault.saveRecording('T0xE', 'audio/webm');
-    // Backdate via the metadata index
+    // Backdate via the metadata index (both createdAt and vaultedAt, since
+    // this recording predates the vaultedAt-based retention clock).
     const index = JSON.parse(localStorage.getItem('engram_audio_vault_index'));
     index[oldId].createdAt = Date.now() - 8 * 24 * 60 * 60 * 1000;
+    index[oldId].vaultedAt = Date.now() - 8 * 24 * 60 * 60 * 1000;
     localStorage.setItem('engram_audio_vault_index', JSON.stringify(index));
     const freshId = await audioVault.saveRecording('RlJFU0g=', 'audio/webm');
 
@@ -63,6 +65,51 @@ describe('audioVault', () => {
     expect(deleted).toBe(1);
     expect(await audioVault.getRecording(oldId)).toBeNull();
     expect(await audioVault.getRecording(freshId)).not.toBeNull();
+  });
+
+  it('retention is measured from vaultedAt, not createdAt: a capture-time-overridden createdAt that looks stale is NOT purged while vaultedAt is fresh', async () => {
+    // e.g. a background-captured recording whose createdAt was overridden to
+    // the original capture time (10 days ago) but was only just swept into
+    // the vault (vaultedAt = now). It should get its full retention window
+    // starting from vaultedAt, not be purged immediately because createdAt
+    // already looks old.
+    const staleCreatedAt = Date.now() - 10 * 24 * 60 * 60 * 1000;
+    const id = await audioVault.saveRecording('QUJD', 'audio/mp4', { createdAt: staleCreatedAt });
+
+    const deleted = await audioVault.cleanupExpired();
+    expect(deleted).toBe(0);
+    expect(await audioVault.getRecording(id)).not.toBeNull();
+  });
+
+  it('retention purges based on a backdated vaultedAt even when createdAt is fresh', async () => {
+    const id = await audioVault.saveRecording('QUJD', 'audio/mp4');
+    const index = JSON.parse(localStorage.getItem('engram_audio_vault_index'));
+    index[id].vaultedAt = Date.now() - 8 * 24 * 60 * 60 * 1000;
+    localStorage.setItem('engram_audio_vault_index', JSON.stringify(index));
+
+    const deleted = await audioVault.cleanupExpired();
+    expect(deleted).toBe(1);
+    expect(await audioVault.getRecording(id)).toBeNull();
+  });
+
+  it('falls back to createdAt for pre-existing entries with no vaultedAt field', async () => {
+    const id = await audioVault.saveRecording('QUJD', 'audio/mp4');
+    const index = JSON.parse(localStorage.getItem('engram_audio_vault_index'));
+    delete index[id].vaultedAt;
+    index[id].createdAt = Date.now() - 8 * 24 * 60 * 60 * 1000;
+    localStorage.setItem('engram_audio_vault_index', JSON.stringify(index));
+
+    const deleted = await audioVault.cleanupExpired();
+    expect(deleted).toBe(1);
+    expect(await audioVault.getRecording(id)).toBeNull();
+  });
+
+  it('saveRecording stamps vaultedAt with the current wall-clock time regardless of a createdAt override', async () => {
+    const before = Date.now();
+    const staleCreatedAt = Date.now() - 10 * 24 * 60 * 60 * 1000;
+    const id = await audioVault.saveRecording('QUJD', 'audio/mp4', { createdAt: staleCreatedAt });
+    const index = JSON.parse(localStorage.getItem('engram_audio_vault_index'));
+    expect(index[id].vaultedAt).toBeGreaterThanOrEqual(before);
   });
 
   it('saveRecording honors options.createdAt (e.g. a background-capture timestamp)', async () => {

--- a/src/services/audio/__tests__/captureInbox.test.js
+++ b/src/services/audio/__tests__/captureInbox.test.js
@@ -124,4 +124,46 @@ describe('sweepCaptureInbox', () => {
     const { files } = await Filesystem.readdir({ path: INBOX, directory: Directory.Data });
     expect(files).toHaveLength(0);
   });
+
+  it('is reentrancy-safe: an overlapping concurrent call is a no-op, not a double-process', async () => {
+    await seed('concurrent', { sidecar: { capturedAt: '2026-01-01T00:00:00.000Z', mime: 'audio/mp4' } });
+
+    // Deliberately don't await the first call before starting the second —
+    // App.jsx can trigger overlapping sweeps (auth + rapid foreground
+    // flapping). The reentrancy guard is set synchronously before the first
+    // await inside sweepCaptureInbox, so the second call below sees it
+    // already in progress and bails immediately.
+    const first = sweepCaptureInbox();
+    const second = sweepCaptureInbox();
+
+    const [firstResults, secondResults] = await Promise.all([first, second]);
+
+    expect(secondResults).toEqual([]);
+    expect(firstResults).toHaveLength(1);
+
+    // Exactly one vault entry was created — no double-processing.
+    expect(await audioVault.listOrphans()).toHaveLength(1);
+  });
+
+  it('deletes an orphan .json sidecar whose matching .m4a no longer exists', async () => {
+    // Simulate a dangling sidecar left behind by e.g. an interrupted delete
+    // or a pre-atomic-write crash on the native side: a .json with no
+    // corresponding .m4a anywhere in the inbox.
+    await Filesystem.mkdir({ path: INBOX, directory: Directory.Data, recursive: true });
+    await Filesystem.writeFile({
+      path: `${INBOX}/dangling.json`,
+      directory: Directory.Data,
+      data: JSON.stringify({ capturedAt: '2026-01-01T00:00:00.000Z', mime: 'audio/mp4' })
+    });
+    // Also seed a normal recording to confirm the cleanup doesn't disturb it.
+    await seed('normal', { sidecar: { capturedAt: '2026-01-02T00:00:00.000Z', mime: 'audio/mp4' } });
+
+    const results = await sweepCaptureInbox();
+
+    expect(results).toHaveLength(1);
+    expect(results[0].capturedAt).toBe('2026-01-02T00:00:00.000Z');
+
+    const { files } = await Filesystem.readdir({ path: INBOX, directory: Directory.Data });
+    expect(files).toHaveLength(0);
+  });
 });

--- a/src/services/audio/__tests__/captureInbox.test.js
+++ b/src/services/audio/__tests__/captureInbox.test.js
@@ -1,0 +1,127 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { Filesystem, Directory } from '@capacitor/filesystem';
+
+// Force the native code path by default so the Filesystem mock is exercised;
+// individual tests flip isNativePlatform back to false via spyOn where needed.
+vi.mock('@capacitor/core', () => ({
+  Capacitor: { isNativePlatform: () => true }
+}));
+
+import { Capacitor } from '@capacitor/core';
+import { sweepCaptureInbox } from '../captureInbox';
+import { audioVault } from '../audioVault';
+
+const INBOX = 'engram-inbox';
+
+// The project's global test setup (src/test/setup.js) stubs `localStorage` as
+// bare vi.fn()s with no backing store. audioVault (which sweepCaptureInbox
+// delegates to for the actual vault write) needs real read-your-write
+// persistence across calls within a test — same shim used in audioVault.test.js.
+beforeEach(() => {
+  const store = new Map();
+  localStorage.getItem.mockImplementation((k) => (store.has(k) ? store.get(k) : null));
+  localStorage.setItem.mockImplementation((k, v) => { store.set(k, String(v)); });
+  localStorage.removeItem.mockImplementation((k) => { store.delete(k); });
+  localStorage.clear.mockImplementation(() => { store.clear(); });
+  Filesystem.__reset();
+  localStorage.clear();
+});
+
+async function seed(id, { sidecar, data = 'QUJDREVG' } = {}) {
+  await Filesystem.mkdir({ path: INBOX, directory: Directory.Data, recursive: true });
+  await Filesystem.writeFile({ path: `${INBOX}/${id}.m4a`, directory: Directory.Data, data });
+  if (sidecar !== undefined) {
+    await Filesystem.writeFile({
+      path: `${INBOX}/${id}.json`,
+      directory: Directory.Data,
+      data: JSON.stringify(sidecar)
+    });
+  }
+}
+
+describe('sweepCaptureInbox', () => {
+  it('returns [] on non-native platforms without touching the filesystem', async () => {
+    const platformSpy = vi.spyOn(Capacitor, 'isNativePlatform').mockReturnValueOnce(false);
+    const readdirSpy = vi.spyOn(Filesystem, 'readdir');
+
+    const result = await sweepCaptureInbox();
+
+    expect(result).toEqual([]);
+    expect(readdirSpy).not.toHaveBeenCalled();
+    platformSpy.mockRestore();
+    readdirSpy.mockRestore();
+  });
+
+  it('returns [] when the inbox directory does not exist yet', async () => {
+    const result = await sweepCaptureInbox();
+    expect(result).toEqual([]);
+  });
+
+  it('sweeps a captured recording with a sidecar into the vault with the overridden createdAt, and empties the inbox', async () => {
+    const capturedAt = '2026-01-01T12:00:00.000Z';
+    await seed('abc', { sidecar: { capturedAt, mime: 'audio/mp4' } });
+
+    const results = await sweepCaptureInbox();
+
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({ mime: 'audio/mp4', capturedAt, base64: 'QUJDREVG' });
+    expect(results[0].recordingId).toBeTruthy();
+
+    // Vault entry carries the capture-time createdAt, not sweep time.
+    const rec = await audioVault.getRecording(results[0].recordingId);
+    expect(rec.createdAt).toBe(Date.parse(capturedAt));
+
+    // Inbox is emptied.
+    const { files } = await Filesystem.readdir({ path: INBOX, directory: Directory.Data });
+    expect(files).toHaveLength(0);
+  });
+
+  it('processes an orphan .m4a with no sidecar using defaults', async () => {
+    await seed('orphan'); // no sidecar written
+    const before = Date.now();
+
+    const results = await sweepCaptureInbox();
+
+    expect(results).toHaveLength(1);
+    expect(results[0].mime).toBe('audio/mp4');
+    expect(Date.parse(results[0].capturedAt)).toBeGreaterThanOrEqual(before);
+
+    const { files } = await Filesystem.readdir({ path: INBOX, directory: Directory.Data });
+    expect(files).toHaveLength(0);
+  });
+
+  it('leaves the inbox files in place when the vault save fails', async () => {
+    await seed('failing', { sidecar: { capturedAt: '2026-01-01T00:00:00.000Z', mime: 'audio/mp4' } });
+    // The first writeFile call after this spy is installed is audioVault's
+    // internal blob write (setup's writeFile calls already ran above).
+    const spy = vi.spyOn(Filesystem, 'writeFile').mockRejectedValueOnce(new Error('disk full'));
+
+    const results = await sweepCaptureInbox();
+
+    expect(results).toHaveLength(0);
+    const { files } = await Filesystem.readdir({ path: INBOX, directory: Directory.Data });
+    expect(files.map(f => f.name).sort()).toEqual(['failing.json', 'failing.m4a']);
+    spy.mockRestore();
+  });
+
+  it('never throws on a malformed sidecar — falls back to defaults', async () => {
+    await seed('bad', { data: 'QUJD' }); // no sidecar from seed()
+    await Filesystem.writeFile({ path: `${INBOX}/bad.json`, directory: Directory.Data, data: 'not json{{' });
+
+    const results = await sweepCaptureInbox();
+
+    expect(results).toHaveLength(1);
+    expect(results[0].mime).toBe('audio/mp4');
+  });
+
+  it('sweeps multiple recordings in one pass', async () => {
+    await seed('one', { sidecar: { capturedAt: '2026-01-01T00:00:00.000Z', mime: 'audio/mp4' } });
+    await seed('two', { sidecar: { capturedAt: '2026-01-02T00:00:00.000Z', mime: 'audio/mp4' } });
+
+    const results = await sweepCaptureInbox();
+
+    expect(results).toHaveLength(2);
+    const { files } = await Filesystem.readdir({ path: INBOX, directory: Directory.Data });
+    expect(files).toHaveLength(0);
+  });
+});

--- a/src/services/audio/audioVault.js
+++ b/src/services/audio/audioVault.js
@@ -65,7 +65,15 @@ export const audioVault = {
         localStorage.setItem(webKey(id), base64);
       }
       const index = readIndex();
-      index[id] = { createdAt: createdAt ?? Date.now(), mime, entryId: null };
+      // vaultedAt is always the wall-clock time this blob actually landed in
+      // the vault, independent of `createdAt` (which callers — e.g. the
+      // background-capture sweep — may override to the original capture
+      // time so journal entries display correctly). Retention must be
+      // measured from vaultedAt: a recording captured 10 days ago but only
+      // just swept into the vault should still get its full 7-day grace
+      // period, not be purged on arrival because its createdAt already
+      // looks stale.
+      index[id] = { createdAt: createdAt ?? Date.now(), vaultedAt: Date.now(), mime, entryId: null };
       const indexed = writeIndex(index);
       if (!indexed) {
         // Blob was written but the index (the only thing that makes it
@@ -145,7 +153,13 @@ export const audioVault = {
     const index = readIndex();
     let deleted = 0;
     for (const [id, meta] of Object.entries(index)) {
-      if (meta.createdAt < cutoff) {
+      // Retention is measured from vaultedAt (when the blob actually landed
+      // in the vault), not createdAt (which may be capture-time-overridden
+      // and could already be "old" the moment it's swept in). Entries
+      // written before this field existed fall back to createdAt so their
+      // existing behavior is unchanged.
+      const retentionClock = meta.vaultedAt || meta.createdAt;
+      if (retentionClock < cutoff) {
         await this.deleteRecording(id);
         deleted++;
       }

--- a/src/services/audio/audioVault.js
+++ b/src/services/audio/audioVault.js
@@ -41,8 +41,17 @@ const emitChanged = () => {
 };
 
 export const audioVault = {
-  /** Returns the recording id, or null if storage failed (never throws). */
-  async saveRecording(base64, mime) {
+  /**
+   * Returns the recording id, or null if storage failed (never throws).
+   * @param {string} base64
+   * @param {string} mime
+   * @param {object} [options]
+   * @param {number} [options.createdAt] - ms-epoch override for the index
+   *   `createdAt` (e.g. the actual capture time for a background-captured
+   *   recording swept in later). Defaults to `Date.now()`.
+   */
+  async saveRecording(base64, mime, options = {}) {
+    const { createdAt } = options;
     const id = `rec_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
     try {
       if (isNative()) {
@@ -56,7 +65,7 @@ export const audioVault = {
         localStorage.setItem(webKey(id), base64);
       }
       const index = readIndex();
-      index[id] = { createdAt: Date.now(), mime, entryId: null };
+      index[id] = { createdAt: createdAt ?? Date.now(), mime, entryId: null };
       const indexed = writeIndex(index);
       if (!indexed) {
         // Blob was written but the index (the only thing that makes it

--- a/src/services/audio/captureInbox.js
+++ b/src/services/audio/captureInbox.js
@@ -1,0 +1,116 @@
+/**
+ * Background-captured recordings (iOS Shortcuts "Record Audio" ->
+ * SaveBrainDumpIntent, see ios/App/App/CaptureIntents.swift) land in an
+ * inbox directory in the app container while Engram is never opened.
+ *
+ * sweepCaptureInbox() moves each pending recording into the audioVault
+ * (durable, indexed storage) and returns items for the caller to run
+ * through the normal transcription pipeline. Inbox files are deleted only
+ * after the vault copy succeeds — a failed vault copy leaves the file in
+ * place so the next sweep (next launch/foreground) retries it.
+ *
+ * Each recording's audioVault entry is stamped with its *capture* time
+ * (from the `<id>.json` sidecar written by the intent), not the time this
+ * sweep runs, so the eventual journal entry reflects when the user actually
+ * spoke rather than whenever the app next happened to open.
+ */
+import { Capacitor } from '@capacitor/core';
+import { Filesystem, Directory, Encoding } from '@capacitor/filesystem';
+import { audioVault } from './audioVault';
+
+const INBOX_DIR = 'engram-inbox';
+const AUDIO_EXT = '.m4a';
+const META_EXT = '.json';
+const DEFAULT_MIME = 'audio/mp4';
+
+const isNative = () => Capacitor.isNativePlatform();
+
+const inboxPath = (name) => `${INBOX_DIR}/${name}`;
+
+/** Best-effort delete — never throws, callers don't need to know if it worked. */
+async function safeDelete(name) {
+  try {
+    await Filesystem.deleteFile({ path: inboxPath(name), directory: Directory.Data });
+  } catch (e) {
+    console.warn('[captureInbox] failed to delete', name, e);
+  }
+}
+
+/**
+ * Reads and parses the `<id>.json` sidecar for a captured recording.
+ * Never throws — falls back to defaults (now / audio/mp4) on any failure,
+ * so a corrupt or unreadable sidecar never blocks the recording itself
+ * from being swept.
+ */
+async function readSidecar(name) {
+  const defaults = { capturedAt: new Date().toISOString(), mime: DEFAULT_MIME };
+  try {
+    const { data } = await Filesystem.readFile({
+      path: inboxPath(name),
+      directory: Directory.Data,
+      encoding: Encoding.UTF8
+    });
+    const meta = JSON.parse(data);
+    return {
+      capturedAt: typeof meta?.capturedAt === 'string' ? meta.capturedAt : defaults.capturedAt,
+      mime: typeof meta?.mime === 'string' ? meta.mime : defaults.mime
+    };
+  } catch (e) {
+    console.warn('[captureInbox] failed to read sidecar', name, e);
+    return defaults;
+  }
+}
+
+export async function sweepCaptureInbox() {
+  if (!isNative()) return [];
+
+  let files;
+  try {
+    ({ files } = await Filesystem.readdir({ path: INBOX_DIR, directory: Directory.Data }));
+  } catch {
+    // Directory doesn't exist yet — nothing has ever been captured.
+    return [];
+  }
+
+  const names = (files || []).map((f) => (typeof f === 'string' ? f : f.name));
+  const nameSet = new Set(names);
+  const ids = [...new Set(
+    names.filter((n) => n.endsWith(AUDIO_EXT)).map((n) => n.slice(0, -AUDIO_EXT.length))
+  )];
+
+  const results = [];
+  for (const id of ids) {
+    const audioName = `${id}${AUDIO_EXT}`;
+    const metaName = `${id}${META_EXT}`;
+    try {
+      const hasSidecar = nameSet.has(metaName);
+      const { capturedAt, mime } = hasSidecar
+        ? await readSidecar(metaName)
+        : { capturedAt: new Date().toISOString(), mime: DEFAULT_MIME };
+
+      const { data: base64 } = await Filesystem.readFile({
+        path: inboxPath(audioName),
+        directory: Directory.Data
+      });
+
+      const recordingId = await audioVault.saveRecording(base64, mime, {
+        createdAt: Date.parse(capturedAt) || Date.now()
+      });
+
+      if (!recordingId) {
+        // Vault write failed — leave both files for the next sweep.
+        continue;
+      }
+
+      await safeDelete(audioName);
+      if (hasSidecar) await safeDelete(metaName);
+
+      results.push({ recordingId, base64, mime, capturedAt });
+    } catch (e) {
+      // Never let one bad file take down the whole sweep.
+      console.warn('[captureInbox] failed to process', id, e);
+    }
+  }
+
+  return results;
+}

--- a/src/services/audio/captureInbox.js
+++ b/src/services/audio/captureInbox.js
@@ -25,6 +25,14 @@ const DEFAULT_MIME = 'audio/mp4';
 
 const isNative = () => Capacitor.isNativePlatform();
 
+// Reentrancy guard: App.jsx sweeps on auth *and* on every foreground
+// transition, so an overlapping call (e.g. rapid foreground/background
+// flapping) is possible. Without this, two concurrent sweeps could both
+// read the same inbox file, double-save it to the vault, and race on
+// deleting it. Module-level (not per-call) because there is only ever one
+// inbox for the whole app.
+let sweepInProgress = false;
+
 const inboxPath = (name) => `${INBOX_DIR}/${name}`;
 
 /** Best-effort delete — never throws, callers don't need to know if it worked. */
@@ -64,53 +72,85 @@ async function readSidecar(name) {
 export async function sweepCaptureInbox() {
   if (!isNative()) return [];
 
-  let files;
-  try {
-    ({ files } = await Filesystem.readdir({ path: INBOX_DIR, directory: Directory.Data }));
-  } catch {
-    // Directory doesn't exist yet — nothing has ever been captured.
+  if (sweepInProgress) {
+    console.log('[captureInbox] sweep already in progress, skipping');
     return [];
   }
-
-  const names = (files || []).map((f) => (typeof f === 'string' ? f : f.name));
-  const nameSet = new Set(names);
-  const ids = [...new Set(
-    names.filter((n) => n.endsWith(AUDIO_EXT)).map((n) => n.slice(0, -AUDIO_EXT.length))
-  )];
-
-  const results = [];
-  for (const id of ids) {
-    const audioName = `${id}${AUDIO_EXT}`;
-    const metaName = `${id}${META_EXT}`;
+  sweepInProgress = true;
+  try {
+    let files;
     try {
-      const hasSidecar = nameSet.has(metaName);
-      const { capturedAt, mime } = hasSidecar
-        ? await readSidecar(metaName)
-        : { capturedAt: new Date().toISOString(), mime: DEFAULT_MIME };
-
-      const { data: base64 } = await Filesystem.readFile({
-        path: inboxPath(audioName),
-        directory: Directory.Data
-      });
-
-      const recordingId = await audioVault.saveRecording(base64, mime, {
-        createdAt: Date.parse(capturedAt) || Date.now()
-      });
-
-      if (!recordingId) {
-        // Vault write failed — leave both files for the next sweep.
-        continue;
-      }
-
-      await safeDelete(audioName);
-      if (hasSidecar) await safeDelete(metaName);
-
-      results.push({ recordingId, base64, mime, capturedAt });
-    } catch (e) {
-      // Never let one bad file take down the whole sweep.
-      console.warn('[captureInbox] failed to process', id, e);
+      ({ files } = await Filesystem.readdir({ path: INBOX_DIR, directory: Directory.Data }));
+    } catch {
+      // Directory doesn't exist yet — nothing has ever been captured.
+      return [];
     }
-  }
 
-  return results;
+    const names = (files || []).map((f) => (typeof f === 'string' ? f : f.name));
+    const nameSet = new Set(names);
+    const ids = [...new Set(
+      names.filter((n) => n.endsWith(AUDIO_EXT)).map((n) => n.slice(0, -AUDIO_EXT.length))
+    )];
+
+    const results = [];
+    for (const id of ids) {
+      const audioName = `${id}${AUDIO_EXT}`;
+      const metaName = `${id}${META_EXT}`;
+      try {
+        const hasSidecar = nameSet.has(metaName);
+        const { capturedAt, mime } = hasSidecar
+          ? await readSidecar(metaName)
+          : { capturedAt: new Date().toISOString(), mime: DEFAULT_MIME };
+
+        const { data: base64 } = await Filesystem.readFile({
+          path: inboxPath(audioName),
+          directory: Directory.Data
+        });
+
+        const recordingId = await audioVault.saveRecording(base64, mime, {
+          createdAt: Date.parse(capturedAt) || Date.now()
+        });
+
+        if (!recordingId) {
+          // Vault write failed — leave both files for the next sweep.
+          continue;
+        }
+
+        await safeDelete(audioName);
+        if (hasSidecar) await safeDelete(metaName);
+
+        results.push({ recordingId, base64, mime, capturedAt });
+      } catch (e) {
+        // Never let one bad file take down the whole sweep.
+        console.warn('[captureInbox] failed to process', id, e);
+      }
+    }
+
+    // Orphan sidecar cleanup: a .json sidecar whose matching .m4a no longer
+    // exists is dead weight that would otherwise linger in the inbox forever
+    // — the main loop above only ever iterates ids derived from *.m4a files,
+    // so a sidecar with no audio file is never visited by it. This can arise
+    // from an interrupted delete (audio deleted, sweep killed before deleting
+    // its sidecar) or a pre-atomic-write crash on the native side. Re-read
+    // the directory (rather than reuse the pre-loop `names` snapshot) so this
+    // reflects what's actually left on disk after the deletes above.
+    try {
+      const { files: filesAfter } = await Filesystem.readdir({ path: INBOX_DIR, directory: Directory.Data });
+      const namesAfter = (filesAfter || []).map((f) => (typeof f === 'string' ? f : f.name));
+      const namesAfterSet = new Set(namesAfter);
+      for (const name of namesAfter) {
+        if (!name.endsWith(META_EXT)) continue;
+        const matchingAudio = `${name.slice(0, -META_EXT.length)}${AUDIO_EXT}`;
+        if (!namesAfterSet.has(matchingAudio)) {
+          await safeDelete(name);
+        }
+      }
+    } catch (e) {
+      console.warn('[captureInbox] orphan sidecar cleanup failed:', e);
+    }
+
+    return results;
+  } finally {
+    sweepInProgress = false;
+  }
 }

--- a/src/test/mocks/filesystem.js
+++ b/src/test/mocks/filesystem.js
@@ -1,5 +1,9 @@
 // src/test/mocks/filesystem.js — in-memory Filesystem for vitest
 const store = new Map();
+// Tracks directories created via mkdir() so readdir() can faithfully throw
+// on a directory that was never created (mirrors real Filesystem plugin
+// behavior — e.g. the capture inbox before anything has ever been written).
+const dirs = new Set();
 
 export const Directory = { Data: 'DATA' };
 export const Encoding = { UTF8: 'utf8' };
@@ -12,11 +16,14 @@ export const Filesystem = {
   },
   async deleteFile({ path }) { store.delete(path); },
   async readdir({ path }) {
+    if (!dirs.has(path)) {
+      throw new Error(`${path} does not exist`);
+    }
     const files = [...store.keys()]
       .filter(p => p.startsWith(path + '/'))
       .map(p => ({ name: p.slice(path.length + 1), type: 'file' }));
     return { files };
   },
-  async mkdir() { /* no-op */ },
-  __reset() { store.clear(); }
+  async mkdir({ path }) { dirs.add(path); },
+  __reset() { store.clear(); dirs.clear(); }
 };


### PR DESCRIPTION
Personal-workflow feature per owner request: record via Shortcuts' Record Audio (Engram never opens); a background App Intent (`SaveBrainDumpIntent`, openAppWhenRun=false) writes m4a + capturedAt sidecar to `Documents/engram-inbox/`; on auth-ready/app-resume the inbox sweeps into the audioVault and through the normal transcription pipeline, with entries **timestamped at capture time** (single `now` override propagates to createdAt/effectiveDate/signals).

Review hardening included: crisis-safe sweep (halts on open crisisModal OR held pendingEntry — single-slot safety state can't be clobbered by a multi-item backlog), sweep reentrancy lock, vault retention now keyed on `vaultedAt` (capture-time backdating can't age recordings into the 7-day purge), atomic intent file writes, orphan-sidecar cleanup.

734/734 tests green, build green, device build verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)